### PR TITLE
Draft: Allow to call showCallkitIncoming() from Objective C code

### DIFF
--- a/ios/Classes/Call.swift
+++ b/ios/Classes/Call.swift
@@ -117,7 +117,8 @@ class Call: NSObject {
     
 }
 
-public class Data {
+@objc
+public class Data : NSObject {
     let uuid: String
     let nameCaller: String
     let appName: String
@@ -145,6 +146,8 @@ public class Data {
     let audioSessionPreferredIOBufferDuration: Double
     
     
+    // TODO Method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C
+    @objc
     public init(args: [String: Any?]) {
         self.uuid = args["id"] as? String ?? ""
         self.nameCaller = args["nameCaller"] as? String ?? ""

--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -20,6 +20,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     static let ACTION_CALL_TOGGLE_GROUP = "com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_GROUP"
     static let ACTION_CALL_TOGGLE_AUDIO_SESSION = "com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_AUDIO_SESSION"
     
+    @objc
     public static var sharedInstance: SwiftFlutterCallkitIncomingPlugin? = nil
     
     private var channel: FlutterMethodChannel? = nil
@@ -104,6 +105,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     }
     
     
+    @objc
     public func showCallkitIncoming(_ data: Data, fromPushKit: Bool) {
         
         self.endCallNotExist(data)


### PR DESCRIPTION
hi @hiennguyen92 

I've added these few lines to allow the method `showCallkitIncoming` to be called from Objective C (https://github.com/hiennguyen92/flutter_callkit_incoming/issues/21)

Still a problem remains.
The initializer of `Data` takes a `[String: Any?]` as param, which cannot be represented in Objective-C.
Can you change it to something representable in Objective-C?

Thanks