### PR TITLE
allow the Ended action Event to fire as previously it was calling dec…

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -385,17 +385,16 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         guard let call = self.callManager?.callWithUUID(uuid: action.callUUID) else {
-            if(self.answerCall == nil && self.outgoingCall == nil){
-                sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TIMEOUT, self.data?.toJSON())
-            }else {
-                sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED, self.data?.toJSON())
-            }
             action.fail()
             return
         }
         call.endCall()
         self.callManager?.removeCall(call)
-        sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_DECLINE, self.data?.toJSON())
+        if (self.answerCall == nil && self.outgoingCall == nil) {
+            sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_DECLINE, self.data?.toJSON())
+        }else {
+            sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED, self.data?.toJSON())
+        }
         action.fulfill()
     }
     


### PR DESCRIPTION
…line if triggered whilst in a call

I've removed the Timeout event from this as it doesn't seem to be relevant.

Right now, this fixes it for me, with my use case, and decline and end call now work, but I think more work is going to be needed to handle situations where users are accepting and ending calls from the same event.  (e.g., call waiting)