### PR TITLE
🐛  reducing avatar to get answers buttons visible

### DIFF
--- a/android/src/main/res/layout/layout_custom_notification.xml
+++ b/android/src/main/res/layout/layout_custom_notification.xml
@@ -37,8 +37,8 @@
 
         <ImageView
             android:id="@+id/ivAvatar"
-            android:layout_width="@dimen/base_margin_x4"
-            android:layout_height="@dimen/base_margin_x4"
+            android:layout_width="@dimen/base_margin_x3"
+            android:layout_height="@dimen/base_margin_x3"
             android:layout_alignParentRight="true"
             android:scaleType="centerCrop"
             android:visibility="invisible" />


### PR DESCRIPTION
problem with galaxy note 20 ultra. 

answers buttons are not visible on the notification : 
<img width="385" alt="image" src="https://user-images.githubusercontent.com/7594598/167886840-1c38a06d-d3de-42e9-a872-f14f64949d1b.png">

reducing avatar size shows 
<img width="385" alt="image" src="https://user-images.githubusercontent.com/7594598/167886973-56551950-d010-470d-96d6-e08abb555417.png">
