### PR TITLE
Check the notification channel during an incoming call

### DIFF
--- a/.idea/libraries/Flutter_Plugins.xml
+++ b/.idea/libraries/Flutter_Plugins.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Flutter Plugins" type="FlutterPluginsLibraryType">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -107,9 +107,13 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
                     callkitNotificationManager.showIncomingNotification(data)
                     sendEventFlutter(ACTION_CALL_INCOMING, data)
                     addCall(context, Data.fromBundle(data))
-                    val soundPlayerServiceIntent = Intent(context, CallkitSoundPlayerService::class.java)
-                    soundPlayerServiceIntent.putExtras(data)
-                    context.startService(soundPlayerServiceIntent)
+
+                    if (callkitNotificationManager.incomingChannelEnabled()) {
+                        val soundPlayerServiceIntent =
+                            Intent(context, CallkitSoundPlayerService::class.java)
+                        soundPlayerServiceIntent.putExtras(data)
+                        context.startService(soundPlayerServiceIntent)
+                    }
                 } catch (error: Exception) {
                     error.printStackTrace()
                 }


### PR DESCRIPTION
If the user turns off only the incoming call channel, ringtones will sound.  
Therefore, the priority of the notification channel must be checked.

![Screenshot](https://user-images.githubusercontent.com/3386962/189639126-e9b34e31-25a2-400e-9c4d-9be2262d9948.png)
