### PR TITLE
Add android notification channel name

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ A Flutter plugin to show incoming call in your Flutter app(Custom for Android/Ca
           'ringtonePath': 'system_ringtone_default',
           'backgroundColor': '#0955fa',
           'backgroundUrl': 'https://i.pravatar.cc/500',
-          'actionColor': '#4CAF50'
+          'actionColor': '#4CAF50',
+          'incomingCallNotificationChannelName': "Incoming Call",
+          'missedCallNotificationChannelName': "Missed Call"
         },
         'ios': <String, dynamic>{
           'iconName': 'CallKitLogo',
@@ -317,6 +319,8 @@ A Flutter plugin to show incoming call in your Flutter app(Custom for Android/Ca
     |     **`backgroundColor`**   | Incoming call screen background color.                                  |     `#0955fa`    |
     |      **`backgroundUrl`**    | Using image background for Incoming call screen. example: http://... https://... or "assets/abc.png"                       |       _None_     |
     |      **`actionColor`**      | Color used in button/text on notification.                              |    `#4CAF50`     |
+    |  **`incomingCallNotificationChannelName`** | Notification channel name of incoming call.              | `Incoming call`  |
+    |  **`missedCallNotificationChannelName`** | Notification channel name of missed call.                  |  `Missed call`   |
 
     <br>
     

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/Call.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/Call.kt
@@ -35,6 +35,7 @@ data class Data(val args: Map<String, Any?>) {
     var actionColor: String
     var isShowMissedCallNotification: Boolean = true
     var incomingCallNotificationChannelName: String? = null
+    var missedCallNotificationChannelName: String? = null
 
     var isAccepted: Boolean = false
 
@@ -50,6 +51,7 @@ data class Data(val args: Map<String, Any?>) {
             actionColor = (android["actionColor"] as? String) ?: "#4CAF50"
             isShowMissedCallNotification = (android["isShowMissedCallNotification"] as? Boolean) ?: true
             incomingCallNotificationChannelName = android["incomingCallNotificationChannelName"] as? String
+            missedCallNotificationChannelName = android["missedCallNotificationChannelName"] as? String
         } else {
             isCustomNotification = (args["isCustomNotification"] as? Boolean) ?: false
             isShowLogo = (args["isShowLogo"] as? Boolean) ?: false
@@ -118,6 +120,10 @@ data class Data(val args: Map<String, Any?>) {
             CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME,
             incomingCallNotificationChannelName
         )
+        bundle.putString(
+            CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME,
+            missedCallNotificationChannelName
+        )
         return bundle
     }
 
@@ -184,6 +190,9 @@ data class Data(val args: Map<String, Any?>) {
             )
             data.incomingCallNotificationChannelName = bundle.getString(
                 CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME
+            )
+            data.missedCallNotificationChannelName = bundle.getString(
+                CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME
             )
             return data
         }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/Call.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/Call.kt
@@ -34,6 +34,7 @@ data class Data(val args: Map<String, Any?>) {
     var backgroundUrl: String
     var actionColor: String
     var isShowMissedCallNotification: Boolean = true
+    var incomingCallNotificationChannelName: String? = null
 
     var isAccepted: Boolean = false
 
@@ -48,6 +49,7 @@ data class Data(val args: Map<String, Any?>) {
             backgroundUrl = (android["backgroundUrl"] as? String) ?: ""
             actionColor = (android["actionColor"] as? String) ?: "#4CAF50"
             isShowMissedCallNotification = (android["isShowMissedCallNotification"] as? Boolean) ?: true
+            incomingCallNotificationChannelName = android["incomingCallNotificationChannelName"] as? String
         } else {
             isCustomNotification = (args["isCustomNotification"] as? Boolean) ?: false
             isShowLogo = (args["isShowLogo"] as? Boolean) ?: false
@@ -112,6 +114,10 @@ data class Data(val args: Map<String, Any?>) {
                 CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_IS_SHOW_MISSED_CALL_NOTIFICATION,
                 isShowMissedCallNotification
         )
+        bundle.putString(
+            CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME,
+            incomingCallNotificationChannelName
+        )
         return bundle
     }
 
@@ -175,6 +181,9 @@ data class Data(val args: Map<String, Any?>) {
             data.isShowMissedCallNotification = bundle.getBoolean(
                     CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_IS_SHOW_MISSED_CALL_NOTIFICATION,
                     true
+            )
+            data.incomingCallNotificationChannelName = bundle.getString(
+                CallkitIncomingBroadcastReceiver.EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME
             )
             return data
         }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -50,6 +50,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         const val EXTRA_CALLKIT_BACKGROUND_URL = "EXTRA_CALLKIT_BACKGROUND_URL"
         const val EXTRA_CALLKIT_ACTION_COLOR = "EXTRA_CALLKIT_ACTION_COLOR"
         const val EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME = "EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME"
+        const val EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME = "EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME"
 
         const val EXTRA_CALLKIT_ACTION_FROM = "EXTRA_CALLKIT_ACTION_FROM"
 
@@ -189,6 +190,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
                 "backgroundUrl" to data.getString(EXTRA_CALLKIT_BACKGROUND_URL, ""),
                 "actionColor" to data.getString(EXTRA_CALLKIT_ACTION_COLOR, ""),
                 "incomingCallNotificationChannelName" to data.getString(EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME, ""),
+                "missedCallNotificationChannelName" to data.getString(EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME, ""),
         )
         val forwardData = mapOf(
                 "id" to data.getString(EXTRA_CALLKIT_ID, ""),

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -49,6 +49,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         const val EXTRA_CALLKIT_BACKGROUND_COLOR = "EXTRA_CALLKIT_BACKGROUND_COLOR"
         const val EXTRA_CALLKIT_BACKGROUND_URL = "EXTRA_CALLKIT_BACKGROUND_URL"
         const val EXTRA_CALLKIT_ACTION_COLOR = "EXTRA_CALLKIT_ACTION_COLOR"
+        const val EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME = "EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME"
 
         const val EXTRA_CALLKIT_ACTION_FROM = "EXTRA_CALLKIT_ACTION_FROM"
 
@@ -186,7 +187,8 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
                 "ringtonePath" to data.getString(EXTRA_CALLKIT_RINGTONE_PATH, ""),
                 "backgroundColor" to data.getString(EXTRA_CALLKIT_BACKGROUND_COLOR, ""),
                 "backgroundUrl" to data.getString(EXTRA_CALLKIT_BACKGROUND_URL, ""),
-                "actionColor" to data.getString(EXTRA_CALLKIT_ACTION_COLOR, "")
+                "actionColor" to data.getString(EXTRA_CALLKIT_ACTION_COLOR, ""),
+                "incomingCallNotificationChannelName" to data.getString(EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME, ""),
         )
         val forwardData = mapOf(
                 "id" to data.getString(EXTRA_CALLKIT_ID, ""),

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -7,7 +7,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.media.RingtoneManager
@@ -26,6 +25,7 @@ import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Comp
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_DURATION
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_HANDLE
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_ID
+import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_IS_CUSTOM_NOTIFICATION
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_NAME_CALLER
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_TEXT_ACCEPT
@@ -86,7 +86,9 @@ class CallkitNotificationManager(private val context: Context) {
         data.putLong(EXTRA_TIME_START_CALL, System.currentTimeMillis())
 
         notificationId = data.getString(EXTRA_CALLKIT_ID, "callkit_incoming").hashCode()
-        createNotificationChanel()
+        createNotificationChanel(
+            data.getString(EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME, "Incoming Call"),
+        )
 
         notificationBuilder = NotificationCompat.Builder(context, "callkit_incoming_channel_id")
         notificationBuilder.setAutoCancel(false)
@@ -214,7 +216,9 @@ class CallkitNotificationManager(private val context: Context) {
 
     fun showMissCallNotification(data: Bundle) {
         notificationId = data.getString(EXTRA_CALLKIT_ID, "callkit_incoming").hashCode() + 1
-        createNotificationChanel()
+        createNotificationChanel(
+            data.getString(EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME, "Incoming Call"),
+        )
         val missedCallSound: Uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
         val typeCall = data.getInt(EXTRA_CALLKIT_TYPE, -1)
         var smallIcon = context.applicationInfo.icon
@@ -330,7 +334,9 @@ class CallkitNotificationManager(private val context: Context) {
         }, 1000)
     }
 
-    private fun createNotificationChanel() {
+    private fun createNotificationChanel(
+        incomingCallChannelName: String,
+    ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             var channelCall = getNotificationManager().getNotificationChannel("callkit_incoming_channel_id")
             if (channelCall != null) {
@@ -338,7 +344,7 @@ class CallkitNotificationManager(private val context: Context) {
             } else {
                 channelCall = NotificationChannel(
                         "callkit_incoming_channel_id",
-                        "Incoming Call",
+                        incomingCallChannelName,
                         NotificationManager.IMPORTANCE_HIGH
                 ).apply {
                     description = ""

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -48,6 +48,7 @@ class CallkitNotificationManager(private val context: Context) {
         const val EXTRA_TIME_START_CALL = "EXTRA_TIME_START_CALL"
 
         private const val NOTIFICATION_CHANNEL_ID_INCOMING = "callkit_incoming_channel_id"
+        private const val NOTIFICATION_CHANNEL_ID_MISSED = "callkit_missed_channel_id"
     }
 
     private lateinit var notificationBuilder: NotificationCompat.Builder
@@ -234,8 +235,8 @@ class CallkitNotificationManager(private val context: Context) {
                 smallIcon = R.drawable.ic_call_missed
             }
         }
-        notificationBuilder = NotificationCompat.Builder(context, "callkit_missed_channel_id")
-        notificationBuilder.setChannelId("callkit_missed_channel_id")
+        notificationBuilder = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID_MISSED)
+        notificationBuilder.setChannelId(NOTIFICATION_CHANNEL_ID_MISSED)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 notificationBuilder.setCategory(Notification.CATEGORY_MISSED_CALL)
@@ -380,7 +381,7 @@ class CallkitNotificationManager(private val context: Context) {
             getNotificationManager().createNotificationChannel(channelCall)
 
             val channelMissedCall = NotificationChannel(
-                    "callkit_missed_channel_id",
+                    NOTIFICATION_CHANNEL_ID_MISSED,
                     missedCallChannelName,
                     NotificationManager.IMPORTANCE_DEFAULT
             ).apply {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -27,6 +27,7 @@ import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Comp
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_ID
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_IS_CUSTOM_NOTIFICATION
+import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_NAME_CALLER
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_TEXT_ACCEPT
 import com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver.Companion.EXTRA_CALLKIT_TEXT_CALLBACK
@@ -88,6 +89,7 @@ class CallkitNotificationManager(private val context: Context) {
         notificationId = data.getString(EXTRA_CALLKIT_ID, "callkit_incoming").hashCode()
         createNotificationChanel(
             data.getString(EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME, "Incoming Call"),
+            data.getString(EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME, "Missed Call"),
         )
 
         notificationBuilder = NotificationCompat.Builder(context, "callkit_incoming_channel_id")
@@ -218,6 +220,7 @@ class CallkitNotificationManager(private val context: Context) {
         notificationId = data.getString(EXTRA_CALLKIT_ID, "callkit_incoming").hashCode() + 1
         createNotificationChanel(
             data.getString(EXTRA_CALLKIT_INCOMING_CALL_NOTIFICATION_CHANNEL_NAME, "Incoming Call"),
+            data.getString(EXTRA_CALLKIT_MISSED_CALL_NOTIFICATION_CHANNEL_NAME, "Missed Call"),
         )
         val missedCallSound: Uri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
         val typeCall = data.getInt(EXTRA_CALLKIT_TYPE, -1)
@@ -336,6 +339,7 @@ class CallkitNotificationManager(private val context: Context) {
 
     private fun createNotificationChanel(
         incomingCallChannelName: String,
+        missedCallChannelName: String,
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             var channelCall = getNotificationManager().getNotificationChannel("callkit_incoming_channel_id")
@@ -364,7 +368,7 @@ class CallkitNotificationManager(private val context: Context) {
 
             val channelMissedCall = NotificationChannel(
                     "callkit_missed_channel_id",
-                    "Missed Call",
+                    missedCallChannelName,
                     NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
                 description = ""

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,6 +37,7 @@ Future<void> showCallkitIncoming(String uuid) async {
       'backgroundUrl': 'https://i.pravatar.cc/500',
       'actionColor': '#4CAF50',
       'incomingCallNotificationChannelName': "Incoming Call",
+      'missedCallNotificationChannelName': "Missed Call",
     },
     'ios': <String, dynamic>{
       'iconName': 'CallKitLogo',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,7 +35,8 @@ Future<void> showCallkitIncoming(String uuid) async {
       'ringtonePath': 'system_ringtone_default',
       'backgroundColor': '#0955fa',
       'backgroundUrl': 'https://i.pravatar.cc/500',
-      'actionColor': '#4CAF50'
+      'actionColor': '#4CAF50',
+      'incomingCallNotificationChannelName': "Incoming Call",
     },
     'ios': <String, dynamic>{
       'iconName': 'CallKitLogo',


### PR DESCRIPTION
Currently, Android notification channel names are fixed.
It can now be passed as optional.

* IncomingCallNotificationChannelName
* MissedCallNotificationChannelName