### PR TITLE
Fixed ringtone sound not playing in Release mode on Android

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerService.kt
@@ -101,7 +101,12 @@ class CallkitSoundPlayerService : Service() {
         } else {
             mediaPlayer?.setAudioStreamType(AudioManager.STREAM_RING)
         }
-        mediaPlayer?.setDataSource(applicationContext, uri)
+        val assetFileDescriptor = applicationContext.getContentResolver().openAssetFileDescriptor(uri, "r")
+        if (assetFileDescriptor != null) {
+            mediaPlayer?.setDataSource(assetFileDescriptor)
+        } else {
+            mediaPlayer?.setDataSource(applicationContext, uri)
+        }
         mediaPlayer?.prepare()
         mediaPlayer?.isLooping = true
         mediaPlayer?.start()


### PR DESCRIPTION
Fixes #105 by using `setDataSource(afd: AssetFileDescriptor)` instead of `setDataSource(context: Context, uri: Uri)`.
Using the URI-based method led to an exception (`java.io.IOException: Prepare failed.: status=0x1`) being thrown by `MediaPlayer.prepare()` which is fixed by using a file descriptor.
This works for the default system ringtone as well as sound files located in `res/raw`.