### PR TITLE
Make FlutterCallkitIncomingPlugin.initSharedInstance non private

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
@@ -48,7 +48,7 @@ class FlutterCallkitIncomingPlugin : FlutterPlugin, MethodCallHandler, ActivityA
             initSharedInstance(flutterPluginBinding.applicationContext, flutterPluginBinding.binaryMessenger, handler)
         }
 
-        private fun initSharedInstance(
+        fun initSharedInstance(
             @NonNull context: Context,
             @NonNull binaryMessenger: BinaryMessenger,
             @Nullable handler: MethodCallHandler?


### PR DESCRIPTION
Needed otherwise it does not work when using the plugin from background isolates