### PR TITLE
Enable speaker button on lock screen

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -295,7 +295,14 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     func configurAudioSession(){
         let session = AVAudioSession.sharedInstance()
         do{
-            try session.setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.allowBluetooth)
+            try session.setCategory(
+                AVAudioSession.Category.playAndRecord,
+                options: [
+                    .allowBluetoothA2DP,
+                    .duckOthers,
+                    .allowBluetooth,
+                ]
+            )
             try session.setMode(self.getAudioSessionMode(data?.audioSessionMode))
             try session.setActive(data?.audioSessionActive ?? true)
             try session.setPreferredSampleRate(data?.audioSessionPreferredSampleRate ?? 44100.0)


### PR DESCRIPTION
The speaker button is not working in the current version.

Add `.allowBluetoothA2DP`  and `.duckOthers` options.

<image height="700px" src="https://user-images.githubusercontent.com/3386962/211777224-c293f991-046e-4142-8924-87f5c028ac1a.jpg" />
