### PR TITLE
Fix on broadcast receiver delay after accepting incoming call on Android

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -285,6 +285,7 @@ class CallkitIncomingActivity : Activity() {
             startActivities(arrayOf(intent, intentTransparent))
         } else {
             val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(this@CallkitIncomingActivity, data)
+            acceptIntent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
             sendBroadcast(acceptIntent)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/TransparentActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/TransparentActivity.kt
@@ -46,7 +46,7 @@ class TransparentActivity : Activity() {
             "ACCEPT" -> {
                 val data = intent.getBundleExtra("data")
                 val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(this@TransparentActivity, data)
-                acceptIntent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
+                acceptIntent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
                 sendBroadcast(acceptIntent)
                 if(isTaskRoot) {
                     val intent = packageManager.getLaunchIntentForPackage(packageName)?.cloneFilter()

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/TransparentActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/TransparentActivity.kt
@@ -46,6 +46,7 @@ class TransparentActivity : Activity() {
             "ACCEPT" -> {
                 val data = intent.getBundleExtra("data")
                 val acceptIntent = CallkitIncomingBroadcastReceiver.getIntentAccept(this@TransparentActivity, data)
+                acceptIntent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
                 sendBroadcast(acceptIntent)
                 if(isTaskRoot) {
                     val intent = packageManager.getLaunchIntentForPackage(packageName)?.cloneFilter()


### PR DESCRIPTION
Most of the times on Android, there's a delay between accepting the call and establishing communication. Event the notification sound keeps on ringing for a while.

By adding the flag FLAG_RECEIVER_FOREGROUND to the CallkitIncomingBroadcastReceiver, we're making sure the event after tapping the "Accept call" button will be called right away.