### PR TITLE
Adapt flutter_lints and use lowerCamelCase to Event enum.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -201,48 +201,48 @@ class HomePageState extends State<HomePage> {
       FlutterCallkitIncoming.onEvent.listen((event) async {
         print('HOME: $event');
         switch (event!.event) {
-          case Event.ACTION_CALL_INCOMING:
+          case Event.actionCallIncoming:
             // TODO: received an incoming call
             break;
-          case Event.ACTION_CALL_START:
+          case Event.actionCallStart:
             // TODO: started an outgoing call
             // TODO: show screen calling in Flutter
             break;
-          case Event.ACTION_CALL_ACCEPT:
+          case Event.actionCallAccept:
             // TODO: accepted an incoming call
             // TODO: show screen calling in Flutter
             NavigationService.instance
                 .pushNamedIfNotCurrent(AppRoute.callingPage, args: event.body);
             break;
-          case Event.ACTION_CALL_DECLINE:
+          case Event.actionCallDecline:
             // TODO: declined an incoming call
             await requestHttp("ACTION_CALL_DECLINE_FROM_DART");
             break;
-          case Event.ACTION_CALL_ENDED:
+          case Event.actionCallEnded:
             // TODO: ended an incoming/outgoing call
             break;
-          case Event.ACTION_CALL_TIMEOUT:
+          case Event.actionCallTimeout:
             // TODO: missed an incoming call
             break;
-          case Event.ACTION_CALL_CALLBACK:
+          case Event.actionCallCallback:
             // TODO: only Android - click action `Call back` from missed call notification
             break;
-          case Event.ACTION_CALL_TOGGLE_HOLD:
+          case Event.actionCallToggleHold:
             // TODO: only iOS
             break;
-          case Event.ACTION_CALL_TOGGLE_MUTE:
+          case Event.actionCallToggleMute:
             // TODO: only iOS
             break;
-          case Event.ACTION_CALL_TOGGLE_DMTF:
+          case Event.actionCallToggleDmtf:
             // TODO: only iOS
             break;
-          case Event.ACTION_CALL_TOGGLE_GROUP:
+          case Event.actionCallToggleGroup:
             // TODO: only iOS
             break;
-          case Event.ACTION_CALL_TOGGLE_AUDIO_SESSION:
+          case Event.actionCallToggleAudioSession:
             // TODO: only iOS
             break;
-          case Event.ACTION_DID_UPDATE_DEVICE_PUSH_TOKEN_VOIP:
+          case Event.actionDidUpdateDevicePushTokenVoip:
             // TODO: only iOS
             break;
         }

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -245,6 +245,8 @@ class HomePageState extends State<HomePage> {
           case Event.actionDidUpdateDevicePushTokenVoip:
             // TODO: only iOS
             break;
+          case Event.actionCallCustom:
+            break;
         }
         if (callback != null) {
           callback(event.toString());

--- a/lib/entities/call_event.dart
+++ b/lib/entities/call_event.dart
@@ -9,53 +9,53 @@ class CallEvent {
 }
 
 enum Event {
-  ACTION_DID_UPDATE_DEVICE_PUSH_TOKEN_VOIP,
-  ACTION_CALL_INCOMING,
-  ACTION_CALL_START,
-  ACTION_CALL_ACCEPT,
-  ACTION_CALL_DECLINE,
-  ACTION_CALL_ENDED,
-  ACTION_CALL_TIMEOUT,
-  ACTION_CALL_CALLBACK,
-  ACTION_CALL_TOGGLE_HOLD,
-  ACTION_CALL_TOGGLE_MUTE,
-  ACTION_CALL_TOGGLE_DMTF,
-  ACTION_CALL_TOGGLE_GROUP,
-  ACTION_CALL_TOGGLE_AUDIO_SESSION,
-  ACTION_CALL_CUSTOM,
+  actionDidUpdateDevicePushTokenVoip,
+  actionCallIncoming,
+  actionCallStart,
+  actionCallAccept,
+  actionCallDecline,
+  actionCallEnded,
+  actionCallTimeout,
+  actionCallCallback,
+  actionCallToggleHold,
+  actionCallToggleMute,
+  actionCallToggleDmtf,
+  actionCallToggleGroup,
+  actionCallToggleAudioSession,
+  actionCallCustom,
 }
 
 /// Using extension for backward compatibility Dart SDK 2.17.0 and lower
 extension EventX on Event {
   String get name {
     switch (this) {
-      case Event.ACTION_DID_UPDATE_DEVICE_PUSH_TOKEN_VOIP:
+      case Event.actionDidUpdateDevicePushTokenVoip:
         return 'com.hiennv.flutter_callkit_incoming.DID_UPDATE_DEVICE_PUSH_TOKEN_VOIP';
-      case Event.ACTION_CALL_INCOMING:
+      case Event.actionCallIncoming:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING';
-      case Event.ACTION_CALL_START:
+      case Event.actionCallStart:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_START';
-      case Event.ACTION_CALL_ACCEPT:
+      case Event.actionCallAccept:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_ACCEPT';
-      case Event.ACTION_CALL_DECLINE:
+      case Event.actionCallDecline:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_DECLINE';
-      case Event.ACTION_CALL_ENDED:
+      case Event.actionCallEnded:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_ENDED';
-      case Event.ACTION_CALL_TIMEOUT:
+      case Event.actionCallTimeout:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_TIMEOUT';
-      case Event.ACTION_CALL_CALLBACK:
+      case Event.actionCallCallback:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_CALLBACK';
-      case Event.ACTION_CALL_TOGGLE_HOLD:
+      case Event.actionCallToggleHold:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_HOLD';
-      case Event.ACTION_CALL_TOGGLE_MUTE:
+      case Event.actionCallToggleMute:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_MUTE';
-      case Event.ACTION_CALL_TOGGLE_DMTF:
+      case Event.actionCallToggleDmtf:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_DMTF';
-      case Event.ACTION_CALL_TOGGLE_GROUP:
+      case Event.actionCallToggleGroup:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_GROUP';
-      case Event.ACTION_CALL_TOGGLE_AUDIO_SESSION:
+      case Event.actionCallToggleAudioSession:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_TOGGLE_AUDIO_SESSION';
-      case Event.ACTION_CALL_CUSTOM:
+      case Event.actionCallCustom:
         return 'com.hiennv.flutter_callkit_incoming.ACTION_CALL_CUSTOM';
     }
   }

--- a/lib/flutter_callkit_incoming.dart
+++ b/lib/flutter_callkit_incoming.dart
@@ -12,9 +12,9 @@ import 'entities/entities.dart';
 
 class FlutterCallkitIncoming {
   static const MethodChannel _channel =
-      const MethodChannel('flutter_callkit_incoming');
+      MethodChannel('flutter_callkit_incoming');
   static const EventChannel _eventChannel =
-      const EventChannel('flutter_callkit_incoming_events');
+      EventChannel('flutter_callkit_incoming_events');
 
   /// Listen to event callback from [FlutterCallkitIncoming].
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   json_serializable: ^6.6.1


### PR DESCRIPTION
This PR is after https://github.com/hiennguyen92/flutter_callkit_incoming/pull/262

I adapt flutter_lists to this project.

enum Event values are used `SCREAMING_CAPS`. However, it is not recommended in Dart.
See https://dart.dev/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names

So This PR converts these Event values into `lowerCamelCase`.

Also,
- Fix `unecessary_const` 
- Add `Event.actionCallCustom` to HomePage in example. (this event is added at https://github.com/hiennguyen92/flutter_callkit_incoming/pull/252)