### PR TITLE
Add `isMuted` to check CallKit mic status on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -132,6 +132,19 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
             self.muteCall(callId, isMuted: isMuted)
             result("OK")
             break
+        case "isMuted":
+            guard let args = call.arguments as? [String: Any] ,
+                  let callId = args["id"] as? String else{
+                result("OK")
+                return
+            }
+            guard let callUUID = UUID(uuidString: callId),
+                  let call = self.callManager.callWithUUID(uuid: callUUID) else {
+                result("OK")
+                return
+            }
+            result(call.isMuted)
+            break
         case "holdCall":
             guard let args = call.arguments as? [String: Any] ,
                   let callId = args["id"] as? String,

--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -135,12 +135,12 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         case "isMuted":
             guard let args = call.arguments as? [String: Any] ,
                   let callId = args["id"] as? String else{
-                result("OK")
+                result(false)
                 return
             }
             guard let callUUID = UUID(uuidString: callId),
                   let call = self.callManager.callWithUUID(uuid: callUUID) else {
-                result("OK")
+                result(false)
                 return
             }
             result(call.isMuted)

--- a/lib/flutter_callkit_incoming.dart
+++ b/lib/flutter_callkit_incoming.dart
@@ -67,7 +67,7 @@ class FlutterCallkitIncoming {
   /// On iOS, using Callkit(update call ui).
   /// On Android, Nothing(only callback event listener).
   static Future<bool> isMuted(String id) async {
-    return await _channel.invokeMethod("isMuted", {'id': id}) as bool? ?? false;
+    return (await _channel.invokeMethod("isMuted", {'id': id})) as bool? ?? false;
   }
 
   /// Hold an Ongoing call.

--- a/lib/flutter_callkit_incoming.dart
+++ b/lib/flutter_callkit_incoming.dart
@@ -63,6 +63,13 @@ class FlutterCallkitIncoming {
     await _channel.invokeMethod("muteCall", {'id': id, 'isMuted': isMuted});
   }
 
+  /// Get Callkit Mic Status (muted/unmuted).
+  /// On iOS, using Callkit(update call ui).
+  /// On Android, Nothing(only callback event listener).
+  static Future<bool> isMuted(String id) async {
+    return await _channel.invokeMethod("isMuted", {'id': id}) as bool? ?? false;
+  }
+
   /// Hold an Ongoing call.
   /// On iOS, using Callkit(update the ongoing call ui).
   /// On Android, Nothing(only callback event listener).


### PR DESCRIPTION
Add support `isMuted` to check the CallKit mic status on iOS.
You can use this function to sync mic status with your app's call engine(agora or webRTC).