### PR TITLE
fix setCallConnected (iOS)

### DIFF
--- a/ios/Classes/CallManager.swift
+++ b/ios/Classes/CallManager.swift
@@ -64,8 +64,16 @@ class CallManager: NSObject {
     }
     
     func connectedCall(call: Call) {
-        let callItem = self.callWithUUID(uuid: call.uuid)
-        callItem?.connectedCall(completion: nil)
+        let answerAction = CXAnswerCallAction(call: call.uuid)        
+        let transaction = CXTransaction(action: answerAction)
+
+        callController.request(transaction) { error in
+            if let error = error {
+                print("Error answering call: \(error.localizedDescription)")
+            } else {
+                // Call successfully answered
+            }
+        }
     }
     
     func endCallAlls() {


### PR DESCRIPTION
Fix issue #304 and #375 
Basically when a custom button answers the call it tells native to "answer the call" and triggers acceptCall event.