### PR TITLE
Fix RECEIVER_EXPORTED on Android14

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,13 +28,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdk 16
+        targetSdk 34
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -104,10 +104,18 @@ class CallkitIncomingActivity : Activity() {
         setContentView(R.layout.activity_callkit_incoming)
         initView()
         incomingData(intent)
-        registerReceiver(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(
+                endedCallkitIncomingBroadcastReceiver,
+                IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}"),
+                Context.RECEIVER_EXPORTED,
+            )
+        } else {
+            registerReceiver(
                 endedCallkitIncomingBroadcastReceiver,
                 IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}")
-        )
+            )
+        }
     }
 
     private fun wakeLockRequest(duration: Long) {


### PR DESCRIPTION
The registerReceiver without export behavior doesn't work on Android 14.

https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported