### PR TITLE
avatar visibility fix

### DIFF
--- a/android/src/main/res/layout-w600dp-land/activity_callkit_incoming.xml
+++ b/android/src/main/res/layout-w600dp-land/activity_callkit_incoming.xml
@@ -48,6 +48,7 @@
                 android:id="@+id/ivAvatar"
                 android:layout_width="@dimen/size_avatar"
                 android:layout_height="@dimen/size_avatar"
+                android:visibility="invisible"
                 android:layout_centerInParent="true"
                 android:src="@drawable/ic_default_avatar"
                 app:civ_border_color="#80ffffff"

--- a/android/src/main/res/layout/activity_callkit_incoming.xml
+++ b/android/src/main/res/layout/activity_callkit_incoming.xml
@@ -48,6 +48,7 @@
                 android:id="@+id/ivAvatar"
                 android:layout_width="@dimen/size_avatar"
                 android:layout_height="@dimen/size_avatar"
+                android:visibility="invisible"
                 android:layout_centerInParent="true"
                 android:src="@drawable/ic_default_avatar"
                 app:civ_border_color="#80ffffff"

--- a/android/src/main/res/layout/layout_custom_notification.xml
+++ b/android/src/main/res/layout/layout_custom_notification.xml
@@ -40,7 +40,7 @@
             android:layout_height="@dimen/base_margin_x4_8"
             android:scaleType="centerCrop"
             android:src="@drawable/ic_default_avatar"
-            android:visibility="visible" />
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout

--- a/android/src/main/res/layout/layout_custom_small_ex_notification.xml
+++ b/android/src/main/res/layout/layout_custom_small_ex_notification.xml
@@ -17,7 +17,7 @@
             android:layout_height="@dimen/base_margin_x4"
             android:scaleType="centerCrop"
             android:src="@drawable/ic_default_avatar"
-            android:visibility="visible" />
+            android:visibility="invisible" />
 
         <LinearLayout
             android:layout_width="@dimen/base_margin_half"

--- a/android/src/main/res/layout/layout_custom_small_notification.xml
+++ b/android/src/main/res/layout/layout_custom_small_notification.xml
@@ -46,7 +46,7 @@
             android:layout_height="@dimen/base_margin_x4"
             android:scaleType="centerCrop"
             android:src="@drawable/ic_default_avatar"
-            android:visibility="visible" />
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
By default, the avatar in notifications should be invisible. When it's set to something other than null, its visibility is changed. Otherwise there is no way to hide it.