### PR TITLE
Restore allowBluetoothA2DP settings

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -402,7 +402,11 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         if data?.configureAudioSession != false {
             let session = AVAudioSession.sharedInstance()
             do{
-                try session.setCategory(AVAudioSession.Category.playAndRecord, options: [.duckOthers,.allowBluetooth])
+                try session.setCategory(AVAudioSession.Category.playAndRecord, options: [
+                    .allowBluetoothA2DP,
+                    .duckOthers,
+                    .allowBluetooth,
+                ])
                 try session.setMode(self.getAudioSessionMode(data?.audioSessionMode))
                 try session.setActive(data?.audioSessionActive ?? true)
                 try session.setPreferredSampleRate(data?.audioSessionPreferredSampleRate ?? 44100.0)


### PR DESCRIPTION
I fixed the bug that the lock screen's speaker button was not working.

https://github.com/hiennguyen92/flutter_callkit_incoming/pull/224

* This is the degrade commit

https://github.com/hiennguyen92/flutter_callkit_incoming/commit/49ae4ff769a8d790ae7f51c10b6d575b00ad968c#diff-8500b178c14b6f8d9c321c8b04e1a5bd89bf90e6d64803b8ff647bcdbe5e9ddfR393

Please restore this setting.
