### PR TITLE
fix: remove duplicate sendBroadcast without data

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/telecom/TelecomConnection.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/telecom/TelecomConnection.kt
@@ -91,7 +91,6 @@ class TelecomConnection internal constructor(private val context: Context, priva
 				put(EXTRA_CALLKIT_ID, uuid)
 			}
 		}
-		context.sendBroadcast(CallkitIncomingBroadcastReceiver.getIntentEnded(context, bundleOf(*data.toList().toTypedArray())))
 		try {
 			TelecomConnectionService.deinitConnection(handle[EXTRA_CALLKIT_ID] ?: "")
 


### PR DESCRIPTION
The lib is with bug, becase in endCall the event is call 2 times where last call is without data.