### PR TITLE
Refactor(android): Improve plugin lifecycle

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -81,7 +81,10 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
             }
     }
 
-    private val callkitNotificationManager: CallkitNotificationManager? = FlutterCallkitIncomingPlugin.getInstance()?.getCallkitNotificationManager()
+    // Get notification manager dynamically to handle plugin lifecycle properly
+    private fun getCallkitNotificationManager(): CallkitNotificationManager? {
+        return FlutterCallkitIncomingPlugin.getInstance()?.getCallkitNotificationManager()
+    }
 
 
     @SuppressLint("MissingPermission")
@@ -91,7 +94,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         when (action) {
             "${context.packageName}.${CallkitConstants.ACTION_CALL_INCOMING}" -> {
                 try {
-                    callkitNotificationManager?.showIncomingNotification(data)
+                    getCallkitNotificationManager()?.showIncomingNotification(data)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_INCOMING, data)
                     addCall(context, Data.fromBundle(data))
                 } catch (error: Exception) {
@@ -132,7 +135,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
             "${context.packageName}.${CallkitConstants.ACTION_CALL_DECLINE}" -> {
                 try {
                     // clear notification
-                    callkitNotificationManager?.clearIncomingNotification(data, false)
+                    getCallkitNotificationManager()?.clearIncomingNotification(data, false)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_DECLINE, data)
                     removeCall(context, Data.fromBundle(data))
                 } catch (error: Exception) {
@@ -143,7 +146,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
             "${context.packageName}.${CallkitConstants.ACTION_CALL_ENDED}" -> {
                 try {
                     // clear notification and stop service
-                    callkitNotificationManager?.clearIncomingNotification(data, false)
+                    getCallkitNotificationManager()?.clearIncomingNotification(data, false)
                     CallkitNotificationService.stopService(context)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_ENDED, data)
                     removeCall(context, Data.fromBundle(data))
@@ -155,8 +158,9 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
             "${context.packageName}.${CallkitConstants.ACTION_CALL_TIMEOUT}" -> {
                 try {
                     // clear notification and show miss notification
-                    callkitNotificationManager?.clearIncomingNotification(data, false)
-                    callkitNotificationManager?.showMissCallNotification(data)
+                    val notificationManager = getCallkitNotificationManager()
+                    notificationManager?.clearIncomingNotification(data, false)
+                    notificationManager?.showMissCallNotification(data)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_TIMEOUT, data)
                     removeCall(context, Data.fromBundle(data))
                 } catch (error: Exception) {
@@ -167,7 +171,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
             "${context.packageName}.${CallkitConstants.ACTION_CALL_CONNECTED}" -> {
                 try {
                     // update notification on going connected
-                    callkitNotificationManager?.showOngoingCallNotification(data, true)
+                    getCallkitNotificationManager()?.showOngoingCallNotification(data, true)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_CONNECTED, data)
                 } catch (error: Exception) {
                     Log.e(TAG, null, error)
@@ -176,7 +180,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
 
             "${context.packageName}.${CallkitConstants.ACTION_CALL_CALLBACK}" -> {
                 try {
-                    callkitNotificationManager?.clearMissCallNotification(data)
+                    getCallkitNotificationManager()?.clearMissCallNotification(data)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_CALLBACK, data)
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                         val closeNotificationPanel = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)


### PR DESCRIPTION
### Overview

This pull request introduces improvements to the Android plugin's lifecycle management. The notification and sound managers are now managed to prevent them from being destroyed prematurely when a foreground service with flutter_background_service is detached. This ensures that the plugin remains active and can receive calls.

### Problem Solved

When a foreground service start with Flutter Engine and subsequently being stopped, FlutterCallkitIncomingPlugin will no longer work as expected. This is due to the onDetachedFromEngine method:
1. Removes the MethodChannel and EventChannel for the specific BinaryMessenger
2. Calls destroy() on callkitSoundPlayerManager and callkitNotificationManager and sets them to null.
3. This affects the singleton instance, which is shared across all Flutter engines (main app and foreground service). As a result, when the foreground service's Flutter engine is detached (e.g., when the service stops), the main app’s ability to use the plugin (e.g., call showCallkitIncoming()) is broken because callkitNotificationManager and other resources are nullified.
