### PR TITLE
Enhance Incoming Call Vibration Persistence When App is Killed

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerManager.kt
@@ -91,7 +91,11 @@ class CallkitSoundPlayerManager(private val context: Context) {
                         VibrationEffect.createWaveform(
                             longArrayOf(0L, 1000L, 1000L),
                             0
-                        )
+                        ),
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build()
                     )
                 } else {
                     vibrator?.vibrate(longArrayOf(0L, 1000L, 1000L), 0)


### PR DESCRIPTION
**Description**

When app is killed, device only can vibrate once with the following OS error: 

> Ignoring incoming vibration as process with uid= 10309 is background, attrs= VibrationAttributes{mUsage=UNKNOWN, mAudioUsage= USAGE_UNKNOWN,mFlags=0


**Changes**

- Implemented vibration logic to run independently of app state.
- Configured AudioAttributes for proper notification handling in background.

