### PR TITLE
Implement volume key handling to mute incoming call sound on key press

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -1,3 +1,10 @@
+//  Modification by Signify in this file are under the following license:
+//
+//  Copyright 2024, Signify Holding
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package com.hiennv.flutter_callkit_incoming
 
 import android.app.Activity
@@ -12,6 +19,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.KeyEvent
 import android.view.View
 import android.view.Window
 import android.view.WindowManager
@@ -359,6 +367,19 @@ class CallkitIncomingActivity : Activity() {
         unregisterReceiver(endedCallkitIncomingBroadcastReceiver)
         super.onDestroy()
     }
+
+    // Start Signify modification
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+            val soundPlayerManager = FlutterCallkitIncomingPlugin.getInstance()?.getCallkitSoundPlayerManager()
+            if (soundPlayerManager?.isPlaying == true) {
+                soundPlayerManager.stop()
+                return true 
+            }
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+    // End Signify modification
 
     override fun onBackPressed() {}
 }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -1,3 +1,10 @@
+//  Modification by Signify in this file are under the following license:
+//
+//  Copyright 2024, Signify Holding
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package com.hiennv.flutter_callkit_incoming
 
 import android.Manifest
@@ -7,11 +14,14 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Color
+import android.media.AudioManager
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
@@ -46,6 +56,10 @@ class CallkitNotificationManager(
     }
 
     private var dataNotificationPermission: Map<String, Any> = HashMap()
+
+    // Start Signify modification
+    private var volumeKeyReceiver: VolumeKeyBroadcastReceiver? = null
+    // End Signify modification
 
     private var notificationBuilder: NotificationCompat.Builder? = null
     private var notificationViews: RemoteViews? = null
@@ -823,8 +837,19 @@ class CallkitNotificationManager(
         return notification?.let { CallkitNotification(onGoingNotificationId, it) }
     }
 
-
     fun clearIncomingNotification(data: Bundle, isAccepted: Boolean) {
+        // Start Signify modification
+        // Unregister volume key receiver
+        volumeKeyReceiver?.let {
+            try {
+                context.unregisterReceiver(it)
+            } catch (e: Exception) {
+                // Ignore Receiver may not be registered
+            }
+            volumeKeyReceiver = null
+        }
+        // End Signify modification
+
         callkitSoundPlayerManager?.stop()
 
         context.sendBroadcast(CallkitIncomingActivity.getIntentEnded(context, isAccepted))
@@ -990,11 +1015,30 @@ class CallkitNotificationManager(
         return NotificationManagerCompat.from(context)
     }
 
+    // Start Signify modification
+    inner class VolumeKeyBroadcastReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == "android.media.VOLUME_CHANGED_ACTION") {
+                if (callkitSoundPlayerManager?.isPlaying == true) {
+                    callkitSoundPlayerManager.stop()
+                }
+            }
+        }
+    }
+    // End Signify modification
+
     @SuppressLint("MissingPermission")
     fun showIncomingNotification(data: Bundle) {
         val callkitNotification = getIncomingNotification(data)
         if (incomingChannelEnabled()) {
             callkitSoundPlayerManager?.play(data)
+            // Start Signify modification
+            volumeKeyReceiver = VolumeKeyBroadcastReceiver()
+            context.registerReceiver(
+                volumeKeyReceiver,
+                IntentFilter("android.media.VOLUME_CHANGED_ACTION")
+            )
+            // End Signify modification
         }
         callkitNotification?.let {
             getNotificationManager().notify(

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerManager.kt
@@ -1,3 +1,10 @@
+//  Modification by Signify in this file are under the following license:
+//
+//  Copyright 2024, Signify Holding
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package com.hiennv.flutter_callkit_incoming
 
 import android.content.BroadcastReceiver
@@ -19,9 +26,11 @@ class CallkitSoundPlayerManager(private val context: Context) {
 
     private var ringtone: Ringtone? = null
 
-    private var isPlaying: Boolean = false
-
-
+    // Start Signify modification
+    var isPlaying: Boolean = false
+        private set
+    // End Signify modification
+    
     inner class ScreenOffCallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             if (isPlaying){


### PR DESCRIPTION
On ios when the user presses volume down button the call is muted. On android the call doesn't show this behavior. 

I checked viber and whatsapp they both exhibits the same behavior.



Muting when the incoming call notification is shown: 

https://github.com/user-attachments/assets/05ae89e1-5ccf-454b-9680-fc0f36c3ab02


Muting when the full screen incoming call is shown: 

https://github.com/user-attachments/assets/3b2cbc67-f1a2-4f29-9ab7-5486fbbbfd1e

