### PR TITLE
fix(android): Ringtone/Vibration stopping on auto lock

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -112,6 +112,7 @@ class CallkitIncomingActivity : Activity() {
                 IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}")
             )
         }
+        FlutterCallkitIncomingPlugin.getInstance()?.getCallkitSoundPlayerManager()?.keepRingingOnFullScreen();
     }
 
     private fun wakeLockRequest(duration: Long) {


### PR DESCRIPTION
### Description
When an incoming call notification was presented in a form of a heads-up notification, if the device auto locked when ringing, the ringtone/vibration stopped even though the fullscreen intent was presented.

**Many different solutions were attempted to fix this:**
- Use newWakeLock on the PowerManager to avoid the auto lock when presenting the heads-up notification. Even though this worked well, this is a deprecated method and it could be dangerous to use this method in a public plugin.
- We tried to add a transparent activity that would have the FLAG_KEEP_SCREEN_ON set to true and present it when showing the heads-up notification, but this only worked when the notification was booted when having the application in foreground.

**After some other solutions were attempted, here is the final one:**
Instead of trying to avoid the auto lock, we decided to keep the ringtone/vibration on when the phone auto locks and presents the fullscreen intent activity. To do this, we had to avoid stopping it during 200ms after the fullscreen intent is presented since the plugin is already stopped by the ACTION_SCREEN_OFF intent. This is a bit hackish but there is unfortunately no way to distinguish between an auto lock and a manual press on the power button of the device.

The only downside of the fix is that if a heads-up notification is presented and the user press on the power button, he will need to press it once again when being presented with the fullscreen intent to stop the ringtone/vibration. Still, the press on the power button when the phone is locked will stop the ringtone/vibration.