### PR TITLE
Add optional `onError` completion handler to showCallkitIncoming for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+* Add optional `onError` completion handler to `showCallkitIncoming` for iOS. Allows the host application to handle errors returned by reportNewIncomingCall, providing visibility into failures caused by system-level restrictions (e.g., Do Not Disturb mode) or invalid configurations.
+
 ## 3.0.0
 * Using Plugin DSL for Android, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/743
 * Add Android native callback, thank @joshoconnor89 https://github.com/hiennguyen92/flutter_callkit_incoming/pull/736

--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -255,7 +255,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         return nil
     }
     
-    @objc public func showCallkitIncoming(_ data: Data, fromPushKit: Bool) {
+    @objc public func showCallkitIncoming(_ data: Data, fromPushKit: Bool, onError: ((Error?) -> Void)? = nil) {
         self.isFromPushKit = fromPushKit
         if(fromPushKit){
             self.data = data
@@ -291,6 +291,8 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
                 self.callManager.addCall(call)
                 self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_INCOMING, data.toJSON())
                 self.endCallNotExist(data)
+            } else {
+                onError?(error)
             }
         }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkit_incoming
 description: Flutter Callkit Incoming to show callkit screen in your Flutter app.
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/hiennguyen92/flutter_callkit_incoming
 repository: https://github.com/hiennguyen92/flutter_callkit_incoming
 issue_tracker: https://github.com/hiennguyen92/flutter_callkit_incoming/issues


### PR DESCRIPTION
**Description**
This PR introduces an optional `onError` completion handler to the `showCallkitIncoming` method.

**Motivation**
Currently, when reportNewIncomingCall fails, the error is swallowed within the plugin's native code. There is no mechanism for the host application to know if the call failed to register. This makes debugging difficult and prevents developers from providing user feedback when a call attempt is rejected by the system (e.g., when the device is in "Do Not Disturb" mode).

By exposing this error, developers can handle these scenarios gracefully, log the failure reason, or inform the user why the incoming call UI did not appear.

**Changes**
Updated `showCallkitIncoming` signature to include `onError: ((Error?) -> Void)? = nil`.

Passed the error from `reportNewIncomingCall` to the provided completion handler.

**Example Usage**
You can now handle errors during the call initiation process:
```swift
SwiftFlutterCallkitIncomingPlugin.sharedInstance?.showCallkitIncoming(
    data,
    fromPushKit: true,
    onError: { error in                    
        guard let nsError = error as NSError? else {
            print("Failed to show incoming call: \(String(describing: error))")
            return
        }
        
        // Code 3 = CXErrorCodeIncomingCallErrorFiltered
        if nsError.domain == "com.apple.CallKit.error.incomingcall", nsError.code == 3 {
            print("Call was filtered (likely DND or blocked number)")
            return
        }
        
        print("Failed to show incoming call: \(nsError.localizedDescription)")
    }
)
```