### PR TITLE
fix(ios): dynamically update CXProvider configuration for subsequent calls

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -464,6 +464,8 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         if(self.sharedProvider == nil){
             self.sharedProvider = CXProvider(configuration: createConfiguration(data))
             self.sharedProvider?.setDelegate(self, queue: nil)
+        } else {
+            self.sharedProvider?.configuration = createConfiguration(data)
         }
         self.callManager.setSharedProvider(self.sharedProvider!)
     }


### PR DESCRIPTION
Currently, the plugin locks the CXProviderConfiguration to the properties of the very first call the app receives. If the app receives a VoIP push that initializes the provider with supportsVideo: true, all subsequent calls will show the video button on the CallKit UI, even if supportsVideo: false is explicitly passed in their data payload.