### PR TITLE
fix(iOS): restore maximumCallGroups config, hold handler, holdCall event

### DIFF
--- a/ios/flutter_callkit_incoming/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/flutter_callkit_incoming/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -381,7 +381,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
             return
         }
         if call.isOnHold == onHold {
-            self.sendMuteEvent(callId.uuidString,  onHold)
+            self.sendHoldEvent(callId.uuidString, onHold)
         } else {
             self.callManager.holdCall(call: call, onHold: onHold)
         }
@@ -532,8 +532,8 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     func createConfiguration(_ data: Data) -> CXProviderConfiguration {
         let configuration = CXProviderConfiguration(localizedName: data.appName)
         configuration.supportsVideo = data.supportsVideo
-        configuration.maximumCallGroups = 1
-        configuration.maximumCallsPerCallGroup = 1
+        configuration.maximumCallGroups = data.maximumCallGroups
+        configuration.maximumCallsPerCallGroup = data.maximumCallsPerCallGroup
         
         configuration.supportedHandleTypes = [
             CXHandle.HandleType.generic,
@@ -717,7 +717,18 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     
     
     public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
-        action.fail()
+        guard let call = self.callManager.callWithUUID(uuid: action.callUUID) else {
+            action.fail()
+            return
+        }
+        call.isOnHold = action.isOnHold
+        call.isMuted = action.isOnHold
+        self.callManager.setHold(call: call, onHold: action.isOnHold)
+        sendHoldEvent(action.callUUID.uuidString, action.isOnHold)
+        if !action.isOnHold {
+            sendDefaultAudioInterruptionNotificationToStartAudioResource()
+        }
+        action.fulfill()
     }
     
     public func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
@@ -884,3 +895,4 @@ public class FlutterCallkitIncomingPlugin: NSObject, FlutterPlugin {
         SwiftFlutterCallkitIncomingPlugin.register(with: registrar)
     }
 }
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          


### PR DESCRIPTION
## Summary

Three iOS bugs found in 3.1.1 — two regressions and one wrong-event bug.

---

## Bug 1 — `maximumCallGroups` / `maximumCallsPerCallGroup` hardcoded to `1`

**Where:** `createConfiguration()` lines 535–536

`createConfiguration()` sets both values to the literal `1`, silently ignoring whatever the caller passed via `IOSParams`. This contradicts the README (which documents these fields) and breaks the bundled example app, which passes `maximumCallGroups: 2` to support two simultaneous calls.

```swift
// 3.1.1 — wrong
configuration.maximumCallGroups = 1
configuration.maximumCallsPerCallGroup = 1

// fix
configuration.maximumCallGroups = data.maximumCallGroups
configuration.maximumCallsPerCallGroup = data.maximumCallsPerCallGroup
```

Apps that need to show two simultaneous calls (e.g. hold one and start/answer another) pass `maximumCallGroups: 2`. With the hardcoded `1`, CallKit silently rejects the second call registration, making attended transfer and call waiting impossible regardless of configuration.

---

## Bug 2 — `CXSetHeldCallAction` handler replaced with `action.fail()`

**Where:** `provider(_:perform action: CXSetHeldCallAction)`

The entire hold/unhold handler body was reduced to `action.fail()`. This means:

- Every hold attempt fails at the CallKit level — the native hold button appears to activate but immediately bounces back
- No `ACTION_CALL_TOGGLE_HOLD` event reaches Dart
- The call's `isOnHold` state is never updated

Restored implementation sets the call state, notifies Dart, restarts audio on unhold, and fulfills the action:

```swift
// 3.1.1 — wrong
public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
    action.fail()
}

// fix
public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
    guard let call = self.callManager.callWithUUID(uuid: action.callUUID) else {
        action.fail()
        return
    }
    call.isOnHold = action.isOnHold
    call.isMuted = action.isOnHold
    self.callManager.setHold(call: call, onHold: action.isOnHold)
    sendHoldEvent(action.callUUID.uuidString, action.isOnHold)
    if !action.isOnHold {
        sendDefaultAudioInterruptionNotificationToStartAudioResource()
    }
    action.fulfill()
}
```

---

## Bug 3 — `holdCall` fires `sendMuteEvent` instead of `sendHoldEvent`

**Where:** `holdCall(_:onHold:)` — the already-held branch

When `holdCall` is called and the call's hold state already matches the requested value, it fires `sendMuteEvent` instead of `sendHoldEvent`. Dart receives `ACTION_CALL_TOGGLE_MUTE` when it should receive `ACTION_CALL_TOGGLE_HOLD`.

```swift
// 3.1.1 — wrong
if call.isOnHold == onHold {
    self.sendMuteEvent(callId.uuidString,  onHold)

// fix
if call.isOnHold == onHold {
    self.sendHoldEvent(callId.uuidString, onHold)
```

---

## Testing

Tested in a Flutter SIP/VoIP app using CallKit on physical iPhone (simulator does not support CallKit).

**Bug 1:** Confirmed `maximumCallGroups: 2` is now respected — CallKit accepts registration of a second call while the first is held.

**Bug 2:** Confirmed hold/unhold from native lock-screen UI now fires `ACTION_CALL_TOGGLE_HOLD` to Dart and the call toggles correctly.

**Bug 3:** Confirmed the Dart event received on an already-held call is now `ACTION_CALL_TOGGLE_HOLD`, not `ACTION_CALL_TOGGLE_MUTE`.

---

## Checklist

- [x] iOS only — no Android, Dart, or pubspec changes
- [x] Single file changed: `SwiftFlutterCallkitIncomingPlugin.swift`
- [x] No new dependencies
- [x] Backward compatible — restores documented/expected behavior