### PR TITLE
Fix iOS crash on ACTION_CALL_CUSTOM: convert event body instead of unsafe cast

### DIFF
--- a/lib/flutter_callkit_incoming.dart
+++ b/lib/flutter_callkit_incoming.dart
@@ -349,7 +349,7 @@ class FlutterCallkitIncoming {
         }
         return CallEventActionCallToggleAudioSession(isActive);
       case CallEventConstants.actionCallCustom:
-        final body = data['body'] as Map<String, dynamic>?;
+        final body = _convertMap(data['body']) as Map<String, dynamic>?;
         if (body == null) {
           throw const FormatException('[ACTION_CALL_CUSTOM] body is null.');
         }


### PR DESCRIPTION
fixes [#846 ](https://github.com/hiennguyen92/flutter_callkit_incoming/issues/846)