### PR TITLE
fix(android): only add MICROPHONE/CAMERA foreground service types when permission is granted

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationService.kt
@@ -1,10 +1,12 @@
 package com.hiennv.flutter_callkit_incoming
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
@@ -101,8 +103,15 @@ class CallkitNotificationService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             var mask = ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                mask = mask or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-                if (isVideo) {
+                // Since Android 14 (API 34), starting a foreground service with the
+                // MICROPHONE or CAMERA type throws a SecurityException unless the
+                // corresponding runtime permission is already granted. Only add the
+                // types whose permission is granted (e.g. the user may answer a call
+                // before the app ever requested RECORD_AUDIO).
+                if (isPermissionGranted(Manifest.permission.RECORD_AUDIO)) {
+                    mask = mask or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                }
+                if (isVideo && isPermissionGranted(Manifest.permission.CAMERA)) {
                     mask = mask or ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
                 }
             }
@@ -111,6 +120,9 @@ class CallkitNotificationService : Service() {
             startForeground(notificationId, notification)
         }
     }
+
+    private fun isPermissionGranted(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 
 
     override fun onDestroy() {


### PR DESCRIPTION
## Problem

Since Android 14 (API 34), calling `startForeground()` with `FOREGROUND_SERVICE_TYPE_MICROPHONE` (or `_CAMERA`) requires the `RECORD_AUDIO` (or `CAMERA`) runtime permission to already be granted — otherwise the OS throws a `SecurityException` and the app crashes.

## Repro

1. Android 14+ device, app installed but `RECORD_AUDIO` not yet granted (fresh install, or user denied it).
2. Kill the app.
3. Receive an incoming call and tap **Answer** on the notification.
4. `CallkitNotificationService.startForeground()` runs with the MICROPHONE type before the app ever had a chance to request the permission → `SecurityException` → crash.

## Fix

Gate each type on its runtime permission. `PHONE_CALL` is always kept so the service still starts; `MICROPHONE`/`CAMERA` are added whenever their permissions are granted (the normal case for a calling app after first use).

We have been running this fix in production in our own fork.