### PR TITLE
fix(ios): don't re-answer an already-connected call in connectedCall

### DIFF
--- a/ios/flutter_callkit_incoming/Classes/CallManager.swift
+++ b/ios/flutter_callkit_incoming/Classes/CallManager.swift
@@ -74,9 +74,20 @@ class CallManager: NSObject {
     
     func connectedCall(call: Call) {
         let callItem = self.callWithUUID(uuid: call.uuid)
+
+        // Never re-answer an already-connected call. The CXAnswerCallAction
+        // requested below makes the plugin re-emit ACTION_CALL_ACCEPT to the
+        // app; if the app's accept handler calls setCallConnected again, that
+        // becomes an accept -> connect -> answer -> accept loop that freezes
+        // the call UI. Requesting another answer action for a connected call
+        // is never useful.
+        if callItem?.hasConnected == true {
+            print("connectedCall ignored: call already connected \(call.uuid.uuidString)")
+            return
+        }
         callItem?.connectedCall(completion: nil)
-        
-        let answerAction = CXAnswerCallAction(call: call.uuid)        
+
+        let answerAction = CXAnswerCallAction(call: call.uuid)
         let transaction = CXTransaction(action: answerAction)
 
         callController.request(transaction) { error in


### PR DESCRIPTION
## Problem

`CallManager.connectedCall()` always requests a `CXAnswerCallAction`. Performing that action makes the plugin re-emit `ACTION_CALL_ACCEPT` to the Flutter side. If the app's accept handler calls `setCallConnected` (a natural way to handle the accept event), this loops:

```
accept event -> setCallConnected -> connectedCall -> CXAnswerCallAction -> accept event -> ...
```

Each lap re-enters CallKit's transaction machinery and the call UI freezes.

## Fix

Return early when the call is already marked `hasConnected` — requesting another answer action for a connected call is never useful.

We have been running this fix in production in our own fork (originally debugged as an app-freeze-on-answer issue).