### PR TITLE
fix(ios): audio session ordering and end-call action handling for edge cases

### DIFF
--- a/ios/flutter_callkit_incoming/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/flutter_callkit_incoming/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -288,7 +288,12 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
             return
         }
         
-        self.configureAudioSession()
+        // Do NOT configure the audio session before reportNewIncomingCall.
+        // When maximumCallsPerCallGroup == 1 and a call is already active, iOS
+        // rejects the new call (error != nil). Re-activating the shared
+        // AVAudioSession up front would, in that rejected case, still interrupt
+        // the active call's audio (e.g. WebRTC breakage). Configure it only once
+        // the call is successfully reported, matching the fromPushKit variant.
         self.sharedProvider?.reportNewIncomingCall(with: uuid, update: callUpdate) { error in
             if(error == nil) {
                 self.configureAudioSession()
@@ -687,12 +692,20 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         guard let call = self.callManager.callWithUUID(uuid: action.callUUID) else {
+            // The call is not in the manager. This happens when:
+            //   1. iOS relaunched the (killed) app just to deliver this end action, or
+            //   2. a programmatic endCall raced with the user-initiated CXEndCallAction
+            //      that already removed the call.
+            // The user actively ended/declined the call, so report DECLINE (not
+            // TIMEOUT) so the app can notify its backend and stop ringing elsewhere.
+            // Fulfill (not fail) the action: failing a legitimate end action leaves
+            // a stale call in the system UI.
             if(self.answerCall == nil && self.outgoingCall == nil){
-                sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TIMEOUT, self.data?.toJSON())
+                sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_DECLINE, self.data?.toJSON())
             } else {
                 sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED, self.data?.toJSON())
             }
-            action.fail()
+            action.fulfill()
             return
         }
         call.endCall()


### PR DESCRIPTION
Two related fixes for call-teardown / second-call edge cases.

## 1. Don't configure the audio session before `reportNewIncomingCall` (non-PushKit path)

The non-PushKit `showCallkitIncoming` variant activates the shared `AVAudioSession` **before** calling `reportNewIncomingCall`. With `maximumCallsPerCallGroup = 1` (the default), reporting a second incoming call while one is already active makes iOS reject it (`error != nil`) — but by then the audio session has already been re-activated for a call that will never exist, which interrupts the active call's audio (we observed WebRTC audio loss / ICE disconnects).

Fix: configure the audio session only after the call is successfully reported — exactly what the `fromPushKit`/completion variant already does.

## 2. `CXEndCallAction` guard branch: report DECLINE and fulfill the action

When the end action's call UUID is not found in the manager, this happens in practice because:
- iOS relaunched the (killed) app just to deliver the end action, or
- a programmatic `endCall` raced the user-initiated `CXEndCallAction` that already removed the call.

In both cases the user actively ended/declined the call, so send `ACTION_CALL_DECLINE` instead of `ACTION_CALL_TIMEOUT` — apps need to distinguish a decline (notify backend, stop ringing for other parties) from a ring timeout. Also `fulfill()` instead of `fail()` the action: failing a legitimate end action leaves a stale call in the system UI.

We have been running both fixes in production in our own fork.