### PR TITLE
feat(android): complete Telecom hold integration for self-managed calls

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConnection.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConnection.kt
@@ -2,12 +2,14 @@ package com.hiennv.flutter_callkit_incoming
 
 import android.content.Context
 import android.content.Intent
+import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.telecom.Connection
 import android.telecom.DisconnectCause
+import android.telecom.TelecomManager
 import android.util.Log
 import androidx.annotation.RequiresApi
 import java.util.concurrent.ConcurrentHashMap
@@ -35,12 +37,15 @@ import java.util.concurrent.ConcurrentHashMap
  */
 @RequiresApi(Build.VERSION_CODES.M)
 class CallkitConnection(
+    private val appContext: Context,
     val callId: String,
     val bundle: Bundle,
 ) : Connection() {
 
     companion object {
         private const val TAG = "CallkitConnection"
+        private const val RESUME_POLL_GRACE_MS = 2000L
+        private const val RESUME_POLL_INTERVAL_MS = 1000L
 
         /** Bundle key — pass the full call Data bundle through Telecom extras. */
         const val EXTRA_CALL_BUNDLE = "com.hiennv.flutter_callkit_incoming.CALL_BUNDLE"
@@ -68,7 +73,12 @@ class CallkitConnection(
     init {
         connectionProperties = PROPERTY_SELF_MANAGED
         audioModeIsVoip = true
-        connectionCapabilities = CAPABILITY_MUTE or CAPABILITY_SUPPORT_HOLD
+        // CAPABILITY_HOLD ("can be held right now") and CAPABILITY_SUPPORT_HOLD
+        // ("hold feature exists") are distinct flags and Telecom requires BOTH:
+        // when the user answers another call, CallsManager only holds the active
+        // call if it has CAPABILITY_HOLD — otherwise onHold() is never invoked
+        // and the call is disconnected or left running unheld.
+        connectionCapabilities = CAPABILITY_MUTE or CAPABILITY_HOLD or CAPABILITY_SUPPORT_HOLD
         register(callId, this)
         Log.d(TAG, "Connection created id=$callId active=${activeCount()}")
     }
@@ -106,14 +116,102 @@ class CallkitConnection(
         finishWithCause(DisconnectCause.UNKNOWN)
     }
 
+    // Telecom holds this self-managed connection when another call takes over
+    // the audio (e.g. the user dials or answers a cellular call). Forward the
+    // transition to Dart so the app can pause its media — mirrors what iOS
+    // does via CXSetHeldCallAction.
+    //
+    // Telecom does NOT unhold self-managed calls when the other call ends —
+    // the self-managed contract is that the app resumes its own call. So on
+    // hold we start a watcher that polls for the managed call's presence and
+    // self-resumes once it is gone (see resumeWhenManagedCallEnds).
     override fun onHold() {
         super.onHold()
+        Log.d(TAG, "onHold id=$callId")
         setOnHold()
+        FlutterCallkitIncomingPlugin.sendEvent(
+            CallkitConstants.ACTION_CALL_TOGGLE_HOLD,
+            mapOf("id" to callId, "isOnHold" to true),
+        )
+        startResumeWatcher()
     }
 
     override fun onUnhold() {
         super.onUnhold()
+        Log.d(TAG, "onUnhold id=$callId")
+        resume()
+    }
+
+    private fun resume() {
+        stopResumeWatcher()
         setActive()
+        FlutterCallkitIncomingPlugin.sendEvent(
+            CallkitConstants.ACTION_CALL_TOGGLE_HOLD,
+            mapOf("id" to callId, "isOnHold" to false),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Self-resume watcher
+    // -------------------------------------------------------------------------
+
+    private val watcherHandler = Handler(Looper.getMainLooper())
+    private var resumeWatcher: Runnable? = null
+
+    private fun startResumeWatcher() {
+        stopResumeWatcher()
+        val watcher = object : Runnable {
+            override fun run() {
+                if (state != STATE_HOLDING) {
+                    resumeWatcher = null
+                    return
+                }
+                if (isManagedCallActive()) {
+                    watcherHandler.postDelayed(this, RESUME_POLL_INTERVAL_MS)
+                    return
+                }
+                Log.d(TAG, "managed call gone — self-resuming id=$callId")
+                resumeWatcher = null
+                resume()
+            }
+        }
+        resumeWatcher = watcher
+        // Grace delay before the first check: at the instant Telecom holds us
+        // the native call may still be setting up, so an immediate poll could
+        // read "no managed call" and resume prematurely.
+        watcherHandler.postDelayed(watcher, RESUME_POLL_GRACE_MS)
+    }
+
+    private fun stopResumeWatcher() {
+        resumeWatcher?.let { watcherHandler.removeCallbacks(it) }
+        resumeWatcher = null
+    }
+
+    /**
+     * Is a managed (carrier/telephony) call ringing, dialing or active?
+     *
+     * Primary signal: [TelecomManager.isInManagedCall] — precise, counts only
+     * managed calls (never our own self-managed one), but needs the
+     * READ_PHONE_STATE runtime permission. Fallback when not granted: the
+     * audio mode, which telephony sets to MODE_IN_CALL (active) or
+     * MODE_RINGTONE (ringing) for the lifetime of a native call.
+     */
+    private fun isManagedCallActive(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val telecom =
+                appContext.getSystemService(Context.TELECOM_SERVICE) as? TelecomManager
+            if (telecom != null) {
+                try {
+                    return telecom.isInManagedCall
+                } catch (e: SecurityException) {
+                    Log.d(TAG, "isInManagedCall needs READ_PHONE_STATE — audio-mode fallback")
+                }
+            }
+        }
+        val audio = appContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+            ?: return false
+        return audio.mode == AudioManager.MODE_IN_CALL ||
+            audio.mode == AudioManager.MODE_RINGTONE
     }
 
     // -------------------------------------------------------------------------
@@ -196,6 +294,7 @@ class CallkitConnection(
     }
 
     private fun finishWithCause(cause: Int) {
+        stopResumeWatcher()
         try {
             setDisconnected(DisconnectCause(cause))
         } catch (e: Exception) {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConnectionService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConnectionService.kt
@@ -58,7 +58,7 @@ class CallkitConnectionService : ConnectionService() {
 
         Log.d(TAG, "onCreateIncomingConnection id=$callId caller=${data.nameCaller}")
 
-        val connection = CallkitConnection(callId, callBundle).apply {
+        val connection = CallkitConnection(applicationContext, callId, callBundle).apply {
             if (data.nameCaller.isNotEmpty()) {
                 setCallerDisplayName(data.nameCaller, TelecomManager.PRESENTATION_ALLOWED)
             }
@@ -98,7 +98,7 @@ class CallkitConnectionService : ConnectionService() {
 
         Log.d(TAG, "onCreateOutgoingConnection id=$callId callee=${data.nameCaller}")
 
-        val connection = CallkitConnection(callId, callBundle).apply {
+        val connection = CallkitConnection(applicationContext, callId, callBundle).apply {
             if (data.nameCaller.isNotEmpty()) {
                 setCallerDisplayName(data.nameCaller, TelecomManager.PRESENTATION_ALLOWED)
             }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.telecom.TelecomManager
@@ -151,6 +152,54 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
+    /**
+     * Register an *outgoing* call with Telecom as a self-managed call, so the
+     * OS knows the app has an active call (and can hold it via
+     * [CallkitConnection.onHold] when e.g. a cellular call is answered).
+     * Mirrors [registerTelecomIncomingCall]; Telecom copies
+     * EXTRA_OUTGOING_CALL_EXTRAS into the ConnectionRequest handed to
+     * [CallkitConnectionService.onCreateOutgoingConnection].
+     */
+    @SuppressLint("MissingPermission")
+    private fun registerTelecomOutgoingCall(context: Context, data: Bundle) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val parsed = try {
+            Data.fromBundle(data)
+        } catch (e: Exception) {
+            null
+        } ?: return
+        if (parsed.id.isEmpty()) return
+        if (CallkitConnection.find(parsed.id) != null) {
+            Log.d(TAG, "Telecom call already registered id=${parsed.id} — skip")
+            return
+        }
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.MANAGE_OWN_CALLS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "MANAGE_OWN_CALLS not granted — Telecom outgoing skipped")
+            return
+        }
+        val telecom = context.getSystemService(Context.TELECOM_SERVICE) as? TelecomManager ?: return
+        val manager = InAppCallManager(context.applicationContext)
+        val handle = manager.getPhoneAccountHandle()
+        val outgoingExtras = Bundle().apply {
+            putBundle(CallkitConnection.EXTRA_CALL_BUNDLE, data)
+        }
+        val extras = Bundle().apply {
+            putParcelable(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE, handle)
+            putBundle(TelecomManager.EXTRA_OUTGOING_CALL_EXTRAS, outgoingExtras)
+        }
+        val address = parsed.handle.ifEmpty { parsed.id }
+        try {
+            telecom.placeCall(Uri.fromParts("tel", address, null), extras)
+            Log.d(TAG, "Telecom placeCall id=${parsed.id}")
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Telecom placeCall rejected: ${e.message}")
+        } catch (e: Exception) {
+            Log.w(TAG, "Telecom placeCall error: ${e.message}")
+        }
+    }
+
     private fun driveTelecomConnection(context: Context, data: Bundle, action: String) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
         val parsed = try {
@@ -161,6 +210,9 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         val conn = CallkitConnection.find(parsed.id) ?: return
         when (action) {
             CallkitConstants.ACTION_CALL_ACCEPT -> conn.markAccepted()
+            // Outgoing call answered by the remote side — drive the dialing
+            // connection to active so Telecom treats it as an ongoing call.
+            CallkitConstants.ACTION_CALL_CONNECTED -> conn.markAccepted()
             CallkitConstants.ACTION_CALL_DECLINE -> conn.markDeclined(context)
             CallkitConstants.ACTION_CALL_ENDED -> conn.markEnded()
             CallkitConstants.ACTION_CALL_TIMEOUT -> conn.markMissed()
@@ -195,6 +247,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
 
             "${context.packageName}.${CallkitConstants.ACTION_CALL_START}" -> {
                 try {
+                    registerTelecomOutgoingCall(context, data)
                     // start service and show ongoing call when call is accepted
                     CallkitNotificationService.startServiceWithAction(
                         context,
@@ -269,6 +322,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
 
             "${context.packageName}.${CallkitConstants.ACTION_CALL_CONNECTED}" -> {
                 try {
+                    driveTelecomConnection(context, data, CallkitConstants.ACTION_CALL_CONNECTED)
                     // update notification on going connected
                     getCallkitNotificationManager()?.showOngoingCallNotification(data, true)
                     sendEventFlutter(CallkitConstants.ACTION_CALL_CONNECTED, data)


### PR DESCRIPTION
The self-managed ConnectionService added in 3.1.0 registers incoming calls with Telecom, but the integration stops there — the connection cannot actually be held, hold transitions never reach Flutter, and outgoing calls have no Telecom presence at all. This PR completes it.

## 1. Add `CAPABILITY_HOLD` alongside `CAPABILITY_SUPPORT_HOLD`

Telecom checks `CAPABILITY_HOLD` ("can be held right now") when another call needs the audio — e.g. the user dials or answers a cellular call. `CAPABILITY_SUPPORT_HOLD` alone ("the hold feature exists") is not enough: without `CAPABILITY_HOLD`, `onHold()` is never invoked and the VoIP call is disconnected or left running unheld.

## 2. Emit `ACTION_CALL_TOGGLE_HOLD` from `onHold()`/`onUnhold()`

When Telecom holds/unholds the connection, forward `{id, isOnHold}` to Flutter — mirroring what iOS already sends via `CXSetHeldCallAction` — so apps can pause/resume their media. Today these transitions are invisible to the Dart side on Android.

## 3. Register outgoing calls with Telecom

- `ACTION_CALL_START` → `telecom.placeCall` (same permission gating and duplicate-guard as the incoming path); the existing `onCreateOutgoingConnection` picks it up.
- `ACTION_CALL_CONNECTED` (from `setCallConnected`) → drive the connection from DIALING to ACTIVE.

Without this, the caller's device has no Telecom presence at all — and a connection left in DIALING blocks new outgoing native calls (system popup: *"There is already another call connecting"*).

## 4. Self-resume watcher

Telecom holds a self-managed call when a native call takes the audio, but never unholds it when that call ends — the self-managed contract is that the app resumes its own call, and `onUnhold()` only relays explicit unhold requests (Bluetooth/car UI). Since self-managed apps cannot observe carrier calls via `InCallService`, we poll `TelecomManager.isInManagedCall` (precise by definition: counts only managed calls, never our own) at 1 Hz **only while held**, with an `AudioManager`-mode fallback when `READ_PHONE_STATE` is not granted, and `setActive()` + notify Flutter once the managed call is gone. `onUnhold()` still works and routes through the same resume path.

## Tested

On device (Android 14, Samsung), in a production VoIP app: hold engages on both call parties the moment a native call starts dialing, and the VoIP call resumes within ~1–2s of the native call ending. Incoming/outgoing VoIP calls, decline, and end flows unaffected.

Related PRs from the same production deployment: #848, #849, #850.