### PR TITLE
fix(ios): send isActive (not isActivate) in ACTION_CALL_TOGGLE_AUDIO_SESSION events

### DIFF
--- a/ios/flutter_callkit_incoming/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/flutter_callkit_incoming/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -800,7 +800,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         sendDefaultAudioInterruptionNotificationToStartAudioResource()
         configureAudioSession()
 
-        self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TOGGLE_AUDIO_SESSION, [ "isActivate": true ])
+        self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TOGGLE_AUDIO_SESSION, [ "isActive": true ])
     }
     
     public func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
@@ -814,7 +814,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
             return
         }
         
-        self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TOGGLE_AUDIO_SESSION, [ "isActivate": false ])
+        self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TOGGLE_AUDIO_SESSION, [ "isActive": false ])
     }
     
     private func sendMuteEvent(_ id: String, _ isMuted: Bool) {


### PR DESCRIPTION
## Problem

On iOS, `ACTION_CALL_TOGGLE_AUDIO_SESSION` events never reach Dart listeners.

The provider delegate sends the event body with the key `isActivate`:

```swift
self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TOGGLE_AUDIO_SESSION, [ "isActivate": true ])
```

but the package's own Dart parser reads `isActive` and **throws** when it is missing (`lib/flutter_callkit_incoming.dart`):

```dart
case CallEventConstants.actionCallToggleAudioSession:
  final isActive = body?['isActive'] as bool?;
  if (isActive == null) {
    throw const FormatException(
        '[ACTION_CALL_TOGGLE_AUDIO_SESSION] id is null.');
  }
  return CallEventActionCallToggleAudioSession(isActive);
```

So every `CXProvider didActivate/didDeactivate audioSession` event errors the event stream with a `FormatException` and is dropped — apps listening via `onEvent` never receive a single audio-session event on iOS. It is easy to miss because the stream error is silent unless the app adds an `onError` handler.

## Fix

Rename the Swift key to `isActive`, matching the Dart parser and the public API field `CallEventActionCallToggleAudioSession.isActive` (the documented spelling). Two occurrences: `didActivate` and `didDeactivate`.

## Testing

- Verified on a real device (iPhone, iOS 18): before the patch, answering a CallKit call produced `FormatException: [ACTION_CALL_TOGGLE_AUDIO_SESSION] id is null.` on the event stream and no event; after the patch the `CallEventActionCallToggleAudioSession(isActive: true/false)` events are delivered on activate/deactivate.