### PR TITLE
Fixed native OnDecline callback not running when the app is in termin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,38 +566,120 @@ FlutterCallkitIncomingPlugin.getInstance().sendEventCustom(body: Map<String, Any
 ```
 
 > **Please check full example:** [Example](https://github.com/hiennguyen92/flutter_callkit_incoming/blob/master/example/ios/Runner/AppDelegate.swift)
+**Create MMainApplication.kt in your source directory **
 
-**MainActivity.kt:**
+**MainApplication.kt:**
 ```kotlin
-class MainActivity: FlutterActivity(){
+import android.app.Application
+import android.os.Bundle
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.hiennv.flutter_callkit_incoming.CallkitEventCallback
+import com.hiennv.flutter_callkit_incoming.FlutterCallkitIncomingPlugin
+import io.flutter.embedding.android.FlutterActivity
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
 
-    private var callkitEventCallback = object: CallkitEventCallback{
-        override fun onCallEvent(event: CallkitEventCallback.CallEvent, callData: Bundle) {
-            when (event) {
-                CallkitEventCallback.CallEvent.ACCEPT -> {
-                    // Do something with answer
-                }
-                CallkitEventCallback.CallEvent.DECLINE -> {
-                    // Do something with decline
-                }
-            }
+private const val BASE_URL = "https://your-url/"
+private const val TAG = "com.medeet.app.MainApplication"
+
+
+class MainApplication : Application() {  // or FlutterApplication
+
+
+  private var callkitEventCallback = object: CallkitEventCallback{
+    override fun onCallEvent(event: CallkitEventCallback.CallEvent, callData: Bundle) {
+      when (event) {
+        CallkitEventCallback.CallEvent.ACCEPT -> {
+          // Save accepted call id to SharedPreferences
+          Log.d(TAG, "onAccept - Kotlin")
+
         }
+        CallkitEventCallback.CallEvent.DECLINE -> {
+          Log.d(TAG, "on Decline - Kotlin")
+          val extra = callData.getSerializable("EXTRA_CALLKIT_EXTRA") as? HashMap<String, Any?>
+          Log.d(TAG, "on Decline - $extra")
+          sendDeclineCall(extra)
+        }
+        else -> {
+          // Handle other cases or do nothing
+        }
+      }
+
     }
+  }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        FlutterCallkitIncomingPlugin.registerEventCallback(callkitEventCallback)
+  //Replace with your custom integration
+  private fun sendDeclineCall(extra: HashMap<String, Any?>?) {
+    // Read access token from SharedPreferences
+    val prefs = applicationContext.getSharedPreferences(
+      "FlutterSharedPreferences", Context.MODE_PRIVATE
+    )
+    val accessToken = prefs.getString("flutter.native_access_token", null)
+
+    if (accessToken.isNullOrEmpty()) {
+      Log.d(TAG, "declineCall - No access token found")
+      return
     }
-
-    override fun onDestroy() {
-        FlutterCallkitIncomingPlugin.unregisterEventCallback(callkitEventCallback)
-        super.onDestroy()
-    }
+    val jsonBody = JSONObject((extra ?: emptyMap<String, Any?>()) as Map<*, *>)
 
 
+    Log.d(TAG, "declineCall - body: $jsonBody")
+
+    // Send request on background thread
+    Thread {
+      try {
+        val url = URL("$BASE_URL/declineCall")
+        val connection = url.openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Content-Type", "application/json")
+        connection.setRequestProperty("Accept", "application/json")
+        connection.setRequestProperty("Authorization", "Bearer $accessToken")
+        connection.doOutput = true
+
+        val writer = OutputStreamWriter(connection.outputStream)
+        writer.write(jsonBody.toString())
+        writer.flush()
+        writer.close()
+        val responseCode = connection.responseCode
+        Log.d(TAG, "declineCall - Response status: $responseCode")
+        connection.disconnect()
+      } catch (e: Exception) {
+        Log.e(TAG, "declineCall - Request error: ${e.message}")
+      }
+    }.start()
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    FlutterCallkitIncomingPlugin.registerEventCallback(callkitEventCallback)
+
+  }
 }
 ```
+***Add this to your app level build file***
+```
+   defaultConfig {
+     
+      ......
+        //Replace with your package name e.g "com.example.app.MainApplication"
+        manifestPlaceholders["applicationName"] = "com.example.flutter_callkit_incoming_example.MainApplication"
 
+    }
+```
+
+***Point ${applicationName} at your new class in Android manifest***
+```
+ <application
+        ....
+        android:name="${applicationName}"
+         <activity
+        
+
+```
 > **Please check full example:** [Example](https://github.com/hiennguyen92/flutter_callkit_incoming/blob/master/example/android/app/src/main/kotlin/com/example/flutter_callkit_incoming_example/MainActivity.kt
 )
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -20,6 +20,9 @@ android {
         versionCode flutter.versionCode
         versionName flutter.versionName
         multiDexEnabled true
+
+        manifestPlaceholders["applicationName"] = "com.example.flutter_callkit_incoming_example.MainApplication"
+
     }
 
     compileOptions {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
    <application
         android:label="flutter_callkit_incoming_example"
-        android:icon="@mipmap/ic_launcher">
+       android:name="${applicationName}"
+       android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleInstance"

--- a/example/android/app/src/main/kotlin/com/example/flutter_callkit_incoming_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/example/flutter_callkit_incoming_example/MainActivity.kt
@@ -7,29 +7,13 @@ import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity(){
 
-    private var callkitEventCallback = object: CallkitEventCallback{
-        override fun onCallEvent(event: CallkitEventCallback.CallEvent, callData: Bundle) {
-            when (event) {
-                CallkitEventCallback.CallEvent.ACCEPT -> {
-                    // Do something with answer
-                }
-                CallkitEventCallback.CallEvent.DECLINE -> {
-                    // Do something with decline
-                }
-                else -> {
 
-                }
-            }
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        FlutterCallkitIncomingPlugin.registerEventCallback(callkitEventCallback)
     }
 
     override fun onDestroy() {
-        FlutterCallkitIncomingPlugin.unregisterEventCallback(callkitEventCallback)
         super.onDestroy()
     }
 

--- a/example/android/app/src/main/kotlin/com/example/flutter_callkit_incoming_example/MainApplication.kt
+++ b/example/android/app/src/main/kotlin/com/example/flutter_callkit_incoming_example/MainApplication.kt
@@ -1,0 +1,50 @@
+package com.example.flutter_callkit_incoming_example
+
+import android.app.Application
+import android.os.Bundle
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.hiennv.flutter_callkit_incoming.CallkitEventCallback
+import com.hiennv.flutter_callkit_incoming.FlutterCallkitIncomingPlugin
+import io.flutter.embedding.android.FlutterActivity
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+private const val TAG = "com.example.flutter_callkit_incoming_example.MainApplication"
+
+class MainApplication : Application() {  // or FlutterApplication
+
+    private var callkitEventCallback = object: CallkitEventCallback{
+        override fun onCallEvent(event: CallkitEventCallback.CallEvent, callData: Bundle) {
+            when (event) {
+                CallkitEventCallback.CallEvent.ACCEPT -> {
+                    // Save accepted call id to SharedPreferences
+                    Log.d(TAG, "onAccept - Kotlin")
+
+                }
+                CallkitEventCallback.CallEvent.DECLINE -> {
+                    Log.d(TAG, "on Decline - Kotlin")
+                    val extra = callData.getSerializable("EXTRA_CALLKIT_EXTRA") as? HashMap<String, Any?>
+
+                    Log.d(TAG, "on Decline - $extra")
+                }
+                else -> {
+                    // Handle other cases or do nothing
+                }
+            }
+
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        FlutterCallkitIncomingPlugin.registerEventCallback(callkitEventCallback)
+
+    }
+
+
+
+
+}


### PR DESCRIPTION
**Fixed OnDecline callback not running in terminated state on Android**

When there is an incoming call when the app is in terminated state, the CallkitEventCallback.CallEvent.DECLINE on android does not get called, the decline button does nothing, this is because MainActivity never get created and never launched and FlutterCallkitIncomingPlugin.registerEventCallback is called in onCreate method of MainActivity. I fixed this issue by moving the callback registration to Application class instead of main activity since Application.onCreate() runs on every process start. Now both callback get called