### PR TITLE
fix(android): stop incoming ringtone from silencing itself, and silence it on volume-key press

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConnection.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConnection.kt
@@ -111,6 +111,18 @@ class CallkitConnection(
         setOnHold()
     }
 
+    /**
+     * While a Telecom call is ringing, volume-key presses never reach
+     * AudioService — PhoneWindowManager intercepts them and calls
+     * [android.telecom.TelecomManager.silenceRinger], which lands here.
+     * Self-managed connections do their own ringing, so stop our ringtone.
+     */
+    override fun onSilence() {
+        super.onSilence()
+        Log.d(TAG, "onSilence id=$callId")
+        FlutterCallkitIncomingPlugin.getInstance()?.getCallkitSoundPlayerManager()?.stop()
+    }
+
     override fun onUnhold() {
         super.onUnhold()
         setActive()

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -54,6 +54,8 @@ class CallkitNotificationManager(
         const val NOTIFICATION_CHANNEL_ID_ONGOING = "callkit_ongoing_channel_id"
         const val NOTIFICATION_CHANNEL_ID_MISSED = "callkit_missed_channel_id"
 
+        private const val ACTION_VOLUME_CHANGED = "android.media.VOLUME_CHANGED_ACTION"
+        private const val EXTRA_VOLUME_STREAM_TYPE = "android.media.EXTRA_VOLUME_STREAM_TYPE"
     }
 
     private var dataNotificationPermission: Map<String, Any> = HashMap()
@@ -1017,7 +1019,12 @@ class CallkitNotificationManager(
     // Start Signify modification
     inner class VolumeKeyBroadcastReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent?.action == "android.media.VOLUME_CHANGED_ACTION") {
+            if (intent?.action == ACTION_VOLUME_CHANGED) {
+                val streamType =
+                    intent.getIntExtra(EXTRA_VOLUME_STREAM_TYPE, -1)
+                if (streamType != AudioManager.STREAM_RING) {
+                    return
+                }
                 if (callkitSoundPlayerManager?.isPlaying == true) {
                     callkitSoundPlayerManager.stop()
                 }
@@ -1035,7 +1042,7 @@ class CallkitNotificationManager(
             volumeKeyReceiver = VolumeKeyBroadcastReceiver()
             context.registerReceiver(
                 volumeKeyReceiver,
-                IntentFilter("android.media.VOLUME_CHANGED_ACTION")
+                IntentFilter(ACTION_VOLUME_CHANGED)
             )
             // End Signify modification
         }


### PR DESCRIPTION
## Summary

Fixes #827. 
On Android, the incoming ringtone would silence itself after ~1–2 seconds with no user interaction. While fixing that, I found that a genuine volume-key press was *also* not silencing the ringtone at all. This PR addresses both, so ringtone silencing happens only on an actual user action.

## Background

Each incoming call is registered with Telecom as a self-managed `Connection` (`CallkitConnection`), and `CallkitNotificationManager` also registers a `VolumeKeyBroadcastReceiver` for `VOLUME_CHANGED_ACTION` to stop the ringtone when the user presses a volume key.

Two problems with that receiver:

1. Ringtone silences itself (#827).
During Telecom's call audio-route setup, the system emits `VOLUME_CHANGED_ACTION` for non-RING streams. The receiver stops the ringtone on *any* such broadcast, so it misfires within a second or two of the call starting — no user touched anything.

2. Volume-key press does not silence the ringtone.
While a Telecom call is in the `RINGING` state, `PhoneWindowManager` intercepts volume keys before they reach `AudioService` and turns them into`TelecomManager.silenceRinger()`. So no `VOLUME_CHANGED_ACTION` is broadcast at all — the receiver never runs, and the press is silently dropped. `silenceRinger()` is delivered to the app as `Connection.onSilence()`, which `CallkitConnection` did not implement.

## Changes

- `CallkitConnection`: implement `onSilence()` to stop the ringtone/vibration via `CallkitSoundPlayerManager.stop()`. This is the callback that actually fires when the user presses a volume key during a self-managed ringing call.
- `CallkitNotificationManager` / `VolumeKeyBroadcastReceiver`: filter to`STREAM_RING` only, so the non-RING broadcasts emitted during audio-route setup no longer stop the ringtone (#827). This receiver now acts as a fallback for cases where the Telecom registration is not used/accepted. The hard-coded action and extra-key strings are hoisted into `companion object` constants.

Note: an earlier iteration also required `newVolume != prevVolume`, but AOSP broadcasts `VOLUME_CHANGED_ACTION` even when the index is clamped at min/max, which would skip silencing when ring volume is already at the boundary — so the guard is a `STREAM_RING` stream-type check only.

## Testing

Verified on a Pixel 8a (Android 16) with the example app:

- Trigger an incoming call and do not touch the device → ringtone keeps playing (no more self-silencing from #827).
- Press a volume key while ringing → Telecom emits `silenceRinger`, `CallkitConnection.onSilence` fires, and the ringtone stops within ~50 ms.