### PR TITLE
Remove automatic launch of full screen intent settings that crashes CallkitIncomingActivity on Android 14+

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -9,7 +9,6 @@ package com.hiennv.flutter_callkit_incoming
 
 import android.app.Activity
 import android.app.KeyguardManager
-import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -36,7 +35,6 @@ import de.hdodenhof.circleimageview.CircleImageView
 import kotlin.math.abs
 import android.view.ViewGroup.MarginLayoutParams
 import android.os.PowerManager
-import android.provider.Settings
 import android.text.TextUtils
 import android.util.Log
 
@@ -101,16 +99,6 @@ class CallkitIncomingActivity : Activity() {
     @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            val notificationManager =
-                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            if (!notificationManager.canUseFullScreenIntent()) {
-                startActivity(Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
-                    flags = FLAG_ACTIVITY_NEW_TASK
-                    putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-                })
-            }
-        }
         requestedOrientation = if (!Utils.isTablet(this@CallkitIncomingActivity)) {
             ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         } else {


### PR DESCRIPTION
## Problem

On Android 14+ (API 34+), `CallkitIncomingActivity.onCreate()` automatically launches the full-screen intent settings screen when `canUseFullScreenIntent()` returns false:

```kotlin
if (!notificationManager.canUseFullScreenIntent()) {
    startActivity(Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
        flags = FLAG_ACTIVITY_NEW_TASK
        putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
    })
}
```


Some devices do not provide an activity that handles Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT, so this call throws ActivityNotFoundException and crashes the incoming call screen itself:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{.../com.hiennv.flutter_callkit_incoming.CallkitIncomingActivity}
  Caused by: android.content.ActivityNotFoundException: No Activity found to handle Intent
      { act=android.settings.MANAGE_APP_USE_FULL_SCREEN_INTENT flg=0x10000000 (has extras) }
      at com.hiennv.flutter_callkit_incoming.CallkitIncomingActivity.onCreate(CallkitIncomingActivity.kt:108)
```


##  Fix

Remove the automatic launch entirely.

Even on devices where the settings screen exists, opening it right when an incoming call screen appears is disruptive: it covers the call UI at the moment the user is trying to answer. Whether and when to guide the user to this setting should be left to the app, which can already do so through the existing plugin APIs (canUseFullScreenIntent() and requestFullIntentPermission()).


##  Impact

- The incoming call screen no longer crashes on devices without the full-screen intent settings screen
- Apps that want to prompt users for the full-screen intent permission should call the existing plugin APIs at an appropriate time instead of relying on this implicit launch