### PR TITLE
fix(android): always call startForeground to prevent FGS timeout crash

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationService.kt
@@ -2,6 +2,8 @@ package com.hiennv.flutter_callkit_incoming
 
 import android.annotation.SuppressLint
 import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -9,11 +11,14 @@ import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.util.Log
 import androidx.core.content.ContextCompat
 
 class CallkitNotificationService : Service() {
 
     companion object {
+
+        private const val TAG = "CallkitNotificationService"
 
         private val ActionForeground = listOf(
             CallkitConstants.ACTION_CALL_START,
@@ -57,29 +62,45 @@ class CallkitNotificationService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action === CallkitConstants.ACTION_CALL_START) {
-            intent.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
-                ?.let {
-                    if(it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
+        val bundle = intent?.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
+        val isForegroundAction = intent?.action in ActionForeground
+        val needsPlaceholder = isForegroundAction &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                bundle?.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true) == true
+        if (needsPlaceholder) {
+            if (!showPlaceholderForegroundNotification(bundle)) {
+                return START_NOT_STICKY
+            }
+        }
+
+        try {
+            if (intent?.action === CallkitConstants.ACTION_CALL_START) {
+                bundle?.let {
+                    if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
                         getCallkitNotificationManager()?.createNotificationChanel(it)
                         showOngoingCallNotification(it)
-                    }else {
+                    } else {
                         stopSelf()
                     }
                 }
-        }
-        if (intent?.action === CallkitConstants.ACTION_CALL_ACCEPT) {
-            intent.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
-                ?.let {
+            }
+            if (intent?.action === CallkitConstants.ACTION_CALL_ACCEPT) {
+                bundle?.let {
                     getCallkitNotificationManager()?.clearIncomingNotification(it, true)
                     if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
                         showOngoingCallNotification(it)
-                    }else {
+                    } else {
                         stopSelf()
                     }
                 }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to show the ongoing call notification", e)
+            if (needsPlaceholder) {
+                stopSelf()
+            }
         }
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     @SuppressLint("MissingPermission")
@@ -94,6 +115,61 @@ class CallkitNotificationService : Service() {
                 callkitNotification.notification,
                 typeCall > 0
             )
+        }
+    }
+
+    private fun getOnGoingNotificationId(bundle: Bundle): Int {
+        return bundle.getString(
+            CallkitConstants.EXTRA_CALLKIT_CALLING_ID,
+            bundle.getString(CallkitConstants.EXTRA_CALLKIT_ID, "callkit_incoming")
+        ).hashCode()
+    }
+
+    private fun showPlaceholderForegroundNotification(bundle: Bundle?): Boolean {
+        val notificationId = bundle?.let { getOnGoingNotificationId(it) }
+            ?: "callkit_incoming".hashCode()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            if (notificationManager?.getNotificationChannel(CallkitNotificationManager.NOTIFICATION_CHANNEL_ID_ONGOING) == null) {
+                notificationManager?.createNotificationChannel(
+                    NotificationChannel(
+                        CallkitNotificationManager.NOTIFICATION_CHANNEL_ID_ONGOING,
+                        "Ongoing Call",
+                        NotificationManager.IMPORTANCE_LOW
+                    )
+                )
+            }
+        }
+
+        val smallIcon = applicationInfo.icon.takeIf { it != 0 } ?: android.R.drawable.sym_call_incoming
+
+        val notification =
+            androidx.core.app.NotificationCompat.Builder(
+                this,
+                CallkitNotificationManager.NOTIFICATION_CHANNEL_ID_ONGOING
+            )
+                .setContentTitle(applicationInfo.loadLabel(packageManager))
+                .setContentText("Calling...")
+                .setSmallIcon(smallIcon)
+                .setOngoing(true)
+                .build()
+
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    notificationId,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
+                )
+            } else {
+                startForeground(notificationId, notification)
+            }
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start foreground with the placeholder notification", e)
+            stopSelf()
+            false
         }
     }
 


### PR DESCRIPTION
# Summary

`CallkitNotificationService` could crash with `ForegroundServiceDidNotStartInTimeException` (also seen as `ForegroundServiceStartNotAllowedException` / ANR) on Android 8+ when the service was started via `ContextCompat.startForegroundService()` but `startForeground()` was not reached in time — or not reached at all — because the ongoing-call notification failed to build.

This can happen when:
- Building the real ongoing-call notification takes too long or throws (e.g., the notification manager isn't ready yet during plugin lifecycle transitions).
- An exception is raised before `startForeground()` is called, so the promised foreground service never starts.

Once the system has been asked to start a foreground service, it *requires* `startForeground()` to be called within the time limit; it kills the app.

## Changes

- Call `startForeground()` immediately with a lightweight placeholder notification (`showPlaceholderForegroundNotification`) as soon as the service starts for a foreground action (`ACTION_CALL_START` / `ACTION_CALL_ACCEPT`) on API 26+. This guarantees the foreground contract is honored before any heavier work runs.
- The real ongoing-call notification is then built and shown afterwards, replacing the placeholder. Notification building is wrapped in `try/catch`; on failure, it logs the error and calls `stopSelf()` instead of leaving the app in a crashable state.
- If starting the placeholder foreground itself fails, log and `stopSelf()` gracefully.
- Reuse the existing ongoing-call channel (`NOTIFICATION_CHANNEL_ID_ONGOING`), creating it on demand if missing, so the placeholder and the real notification share the same channel and the placeholder is silently upgraded.
- Change the return value from `START_STICKY` to `START_NOT_STICKY`. A call is a transient event; the service should not be automatically recreated by the system with a null intent after being killed.
