### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
+## 3.1.5
+* Fix Android: resolve build errors introduced in 3.1.4.
+* Fix Android: always call `startForeground` to prevent `ForegroundServiceDidNotStartInTimeException`, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/857
+* Fix Android: remove automatic launch of full screen intent settings that crashes `CallkitIncomingActivity` on Android 14+, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/856
+* Fix Android: stop incoming ringtone from silencing itself, and silence it correctly on volume-key press, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/855
+* Fix Android: native `OnDecline` callback not running when app is in terminated state, thank @salamay https://github.com/hiennguyen92/flutter_callkit_incoming/pull/854
+* Fix Android: complete Telecom hold integration for self-managed calls, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/852
+* Fix Android: only add `MICROPHONE`/`CAMERA` foreground service types when permission is granted, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/848
+* Fix Android: restore foreground service on OS restart to prevent microphone loss in background, thank @skutimechanic https://github.com/hiennguyen92/flutter_callkit_incoming/pull/842
+* Fix Android: `ActionCallToggleAudioSession` key name `isActivate` inconsistency, thank @skutimechanic https://github.com/hiennguyen92/flutter_callkit_incoming/pull/836
+* Fix iOS: send `isActive` (not `isActivate`) in `ACTION_CALL_TOGGLE_AUDIO_SESSION` events, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/853
+* Fix iOS: audio session ordering and end-call action handling for edge cases, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/850
+* Fix iOS: don't re-answer an already-connected call in `connectedCall`, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/849
+* Fix iOS: crash on `ACTION_CALL_CUSTOM` — convert event body instead of unsafe cast, thank @andrei-uni https://github.com/hiennguyen92/flutter_callkit_incoming/pull/847
+
 ## 3.1.4
+
 * Fix Android: always call `startForeground` to prevent `ForegroundServiceDidNotStartInTimeException`, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/857
 * Fix Android: remove automatic launch of full screen intent settings that crashes `CallkitIncomingActivity` on Android 14+, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/856
 * Fix Android: stop incoming ringtone from silencing itself, and silence it correctly on volume-key press, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/855

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationService.kt
@@ -35,9 +35,9 @@ class CallkitNotificationService : Service() {
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && intent.action in ActionForeground) {
                 data?.let {
-                    if(it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
+                    if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
                         ContextCompat.startForegroundService(context, intent)
-                    }else {
+                    } else {
                         context.startService(intent)
                     }
                 }
@@ -76,53 +76,60 @@ class CallkitNotificationService : Service() {
         }
 
         try {
-          when (intent?.action) {
-              CallkitConstants.ACTION_CALL_START -> {
-                  intent.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
-                      ?.let {
-                          if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
-                              getCallkitNotificationManager()?.createNotificationChanel(it)
-                              showOngoingCallNotification(it)
-                          } else {
-                              stopSelf()
-                          }
-                      }
-              }
-              CallkitConstants.ACTION_CALL_ACCEPT -> {
-                  intent.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
-                      ?.let {
-                          getCallkitNotificationManager()?.clearIncomingNotification(it, true)
-                          if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
-                              showOngoingCallNotification(it)
-                          } else {
-                              stopSelf()
-                          }
-                      }
-              }
-              null -> {
-                  // OS restarted the service after kill (START_STICKY with null intent).
-                  // Flutter engine may not be running yet — create a standalone manager
-                  // using only Context so we can restore startForeground() without the plugin.
-                  val activeCalls = getDataActiveCalls(this)
-                  val bundle = activeCalls.firstOrNull()?.toBundle()
-                  if (bundle != null) {
-                      val pluginManager = getCallkitNotificationManager()
-                      val manager = pluginManager
-                          ?: CallkitNotificationManager(this, CallkitSoundPlayerManager(this))
-                      manager.createNotificationChanel(bundle)
-                      val notification = manager.getOnGoingCallNotification(bundle, false)
-                      if (notification != null) {
-                          val typeCall = bundle.getInt(CallkitConstants.EXTRA_CALLKIT_TYPE, -1)
-                          startForeground(notification.id, notification.notification, typeCall > 0)
-                          if (pluginManager == null) manager.destroy()
-                      } else {
-                          if (pluginManager == null) manager.destroy()
-                          stopSelf()
-                      }
-                  } else {
-                      stopSelf()
-                  }
-              }
+            when (intent?.action) {
+                CallkitConstants.ACTION_CALL_START -> {
+                    intent.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
+                        ?.let {
+                            if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
+                                getCallkitNotificationManager()?.createNotificationChanel(it)
+                                showOngoingCallNotification(it)
+                            } else {
+                                stopSelf()
+                            }
+                        }
+                }
+
+                CallkitConstants.ACTION_CALL_ACCEPT -> {
+                    intent.getBundleExtra(CallkitConstants.EXTRA_CALLKIT_INCOMING_DATA)
+                        ?.let {
+                            getCallkitNotificationManager()?.clearIncomingNotification(it, true)
+                            if (it.getBoolean(CallkitConstants.EXTRA_CALLKIT_CALLING_SHOW, true)) {
+                                showOngoingCallNotification(it)
+                            } else {
+                                stopSelf()
+                            }
+                        }
+                }
+
+                null -> {
+                    // OS restarted the service after kill (START_STICKY with null intent).
+                    // Flutter engine may not be running yet — create a standalone manager
+                    // using only Context so we can restore startForeground() without the plugin.
+                    val activeCalls = getDataActiveCalls(this)
+                    val bundle = activeCalls.firstOrNull()?.toBundle()
+                    if (bundle != null) {
+                        val pluginManager = getCallkitNotificationManager()
+                        val manager = pluginManager
+                            ?: CallkitNotificationManager(this, CallkitSoundPlayerManager(this))
+                        manager.createNotificationChanel(bundle)
+                        val notification = manager.getOnGoingCallNotification(bundle, false)
+                        if (notification != null) {
+                            val typeCall = bundle.getInt(CallkitConstants.EXTRA_CALLKIT_TYPE, -1)
+                            startForeground(
+                                notification.id,
+                                notification.notification,
+                                typeCall > 0
+                            )
+                            if (pluginManager == null) manager.destroy()
+                        } else {
+                            if (pluginManager == null) manager.destroy()
+                            stopSelf()
+                        }
+                    } else {
+                        stopSelf()
+                    }
+                }
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to show the ongoing call notification", e)
             if (needsPlaceholder) {
@@ -171,7 +178,8 @@ class CallkitNotificationService : Service() {
             }
         }
 
-        val smallIcon = applicationInfo.icon.takeIf { it != 0 } ?: android.R.drawable.sym_call_incoming
+        val smallIcon =
+            applicationInfo.icon.takeIf { it != 0 } ?: android.R.drawable.sym_call_incoming
 
         val notification =
             androidx.core.app.NotificationCompat.Builder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkit_incoming
 description: Flutter Callkit Incoming to show callkit screen in your Flutter app.
-version: 3.1.4
+version: 3.1.5
 homepage: https://github.com/hiennguyen92/flutter_callkit_incoming
 repository: https://github.com/hiennguyen92/flutter_callkit_incoming
 issue_tracker: https://github.com/hiennguyen92/flutter_callkit_incoming/issues


### PR DESCRIPTION
## 3.1.5
* Fix Android: resolve build errors introduced in 3.1.4.
* Fix Android: always call `startForeground` to prevent `ForegroundServiceDidNotStartInTimeException`, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/857
* Fix Android: remove automatic launch of full screen intent settings that crashes `CallkitIncomingActivity` on Android 14+, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/856
* Fix Android: stop incoming ringtone from silencing itself, and silence it correctly on volume-key press, thank @AAkira https://github.com/hiennguyen92/flutter_callkit_incoming/pull/855
* Fix Android: native `OnDecline` callback not running when app is in terminated state, thank @salamay https://github.com/hiennguyen92/flutter_callkit_incoming/pull/854
* Fix Android: complete Telecom hold integration for self-managed calls, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/852
* Fix Android: only add `MICROPHONE`/`CAMERA` foreground service types when permission is granted, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/848
* Fix Android: restore foreground service on OS restart to prevent microphone loss in background, thank @skutimechanic https://github.com/hiennguyen92/flutter_callkit_incoming/pull/842
* Fix Android: `ActionCallToggleAudioSession` key name `isActivate` inconsistency, thank @skutimechanic https://github.com/hiennguyen92/flutter_callkit_incoming/pull/836
* Fix iOS: send `isActive` (not `isActivate`) in `ACTION_CALL_TOGGLE_AUDIO_SESSION` events, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/853
* Fix iOS: audio session ordering and end-call action handling for edge cases, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/850
* Fix iOS: don't re-answer an already-connected call in `connectedCall`, thank @m-lhb https://github.com/hiennguyen92/flutter_callkit_incoming/pull/849
* Fix iOS: crash on `ACTION_CALL_CUSTOM` — convert event body instead of unsafe cast, thank @andrei-uni https://github.com/hiennguyen92/flutter_callkit_incoming/pull/847